### PR TITLE
fix(coap_client): set accept to application/link-format for CoRE Link Format discovery

### DIFF
--- a/lib/src/binding_coap/coap_client.dart
+++ b/lib/src/binding_coap/coap_client.dart
@@ -406,7 +406,8 @@ class CoapClient extends ProtocolClient {
 
     // TODO(JKRhb): Multicast could be supported here as well.
     final request = coap.CoapRequest(coap.CoapCode.get)
-      ..uriPath = discoveryUri.path;
+      ..uriPath = discoveryUri.path
+      ..accept = coap.CoapMediaType.applicationLinkFormat;
     final response = await coapClient.send(request);
 
     coapClient.close();


### PR DESCRIPTION
Previously, the Content-Format `text/plain` was used in an Accept option for discovery with the CoRE Link Format. This PR changes the Content-Format used to `application/link-format` (Content-Format 40) in order to avoid rejection by other implementations. 