### PR TITLE
feat: add Codec for CoRE Link Format

### DIFF
--- a/lib/src/core/codecs/link_format_codec.dart
+++ b/lib/src/core/codecs/link_format_codec.dart
@@ -1,0 +1,42 @@
+// Copyright 2022 The NAMIB Project Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:coap/coap.dart';
+
+import '../../definitions/data_schema.dart';
+import 'content_codec.dart';
+
+/// A [ContentCodec] that encodes and decodes the CoRE Link Format ([RFC 6690]).
+///
+/// [RFC 6690]: https://datatracker.ietf.org/doc/html/rfc6690
+class LinkFormatCodec extends ContentCodec {
+  @override
+  ByteBuffer valueToBytes(
+    Object? value,
+    DataSchema? dataSchema,
+    Map<String, String>? parameters,
+  ) {
+    if (value is CoapIResource) {
+      return Uint8List.fromList(CoapLinkFormat.serialize(value).codeUnits)
+          .buffer;
+    }
+
+    throw FormatException('Error deserializing CoRE Link Format', value);
+  }
+
+  @override
+  Object? bytesToValue(
+    ByteBuffer bytes,
+    DataSchema? dataSchema,
+    Map<String, String>? parameters,
+  ) {
+    final string = utf8.decode(bytes.asUint8List().toList(growable: false));
+    return CoapLinkFormat.parse(string);
+  }
+}

--- a/lib/src/core/content_serdes.dart
+++ b/lib/src/core/content_serdes.dart
@@ -16,6 +16,7 @@ import 'codecs/cbor_codec.dart';
 import 'codecs/codec_media_type.dart';
 import 'codecs/content_codec.dart';
 import 'codecs/json_codec.dart';
+import 'codecs/link_format_codec.dart';
 import 'content.dart';
 
 /// Defines `application/json` as the default content type.
@@ -55,6 +56,7 @@ class ContentSerdes {
   final _codecs = {
     CodecMediaType('application', 'json'): JsonCodec(),
     CodecMediaType('application', 'cbor'): CborCodec(),
+    CodecMediaType('application', 'link-format'): LinkFormatCodec(),
   };
 
   final Set<String> _offeredMediaTypes = {

--- a/test/core/content_serdes_test.dart
+++ b/test/core/content_serdes_test.dart
@@ -58,7 +58,7 @@ void main() {
 
     expect(
       contentSerdes.supportedMediaTypes,
-      ['application/json', 'application/cbor'],
+      ['application/json', 'application/cbor', 'application/link-format'],
     );
 
     expect(
@@ -95,6 +95,16 @@ void main() {
     contentSerdes
       ..assignCodec('application/xml', JsonCodec())
       ..addOfferedMediaType('application/xml');
+
+    expect(
+      contentSerdes.supportedMediaTypes,
+      [
+        'application/json',
+        'application/cbor',
+        'application/link-format',
+        'application/xml',
+      ],
+    );
 
     expect(
       contentSerdes.offeredMediaTypes,


### PR DESCRIPTION
This PR adds a Codec for the CoRE Link Format. The logic is taken from the CoAP library used by dart_wot.