### PR TITLE
refactor(core): simplify codec registration system

### DIFF
--- a/lib/src/core/codecs/codec_media_type.dart
+++ b/lib/src/core/codecs/codec_media_type.dart
@@ -1,0 +1,56 @@
+// Copyright 2022 The NAMIB Project Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// Basic class for associating a codec to a minimal Content-Type.
+class CodecMediaType {
+  /// Constructor.
+  CodecMediaType(this.prefix, this.suffix);
+
+  /// The prefix of this [CodecMediaType], e.g., `application` or `text`.
+  final String prefix;
+
+  /// The suffix of this [CodecMediaType], e.g., `json` or `plain`.
+  final String suffix;
+
+  @override
+  int get hashCode => Object.hash(prefix, suffix);
+
+  @override
+  bool operator ==(Object other) =>
+      other is CodecMediaType &&
+      other.runtimeType == runtimeType &&
+      other.prefix == prefix &&
+      other.suffix == suffix;
+
+  /// Tries to parse a string-based [mediaType] and returns a [CodecMediaType]
+  /// on success or `null` otherwise.
+  ///
+  /// When passing a [mediaType] like `application/td+json`, the part before the
+  /// `+` in the subtype will be ignored (the result will become
+  /// `application/json`). The same holds true for parameters like
+  /// `charset=utf-8`.
+  static CodecMediaType? parse(String mediaType) {
+    final splitMediaType = mediaType.split('/');
+
+    if (splitMediaType.length < 2) {
+      return null;
+    }
+
+    final prefix = splitMediaType.first;
+
+    if (prefix.isEmpty) {
+      return null;
+    }
+
+    final suffix = splitMediaType[1].split(';').first.split('+').last;
+
+    if (suffix.isEmpty) {
+      return null;
+    }
+
+    return CodecMediaType(prefix, suffix);
+  }
+}

--- a/test/core/content_serdes_test.dart
+++ b/test/core/content_serdes_test.dart
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:dart_wot/src/core/codecs/json_codec.dart';
 import 'package:dart_wot/src/core/content.dart';
 import 'package:dart_wot/src/core/content_serdes.dart';
 import 'package:dart_wot/src/definitions/data_schema.dart';
@@ -50,6 +51,63 @@ void main() {
     expect(
       await contentSerdes.contentToValue(testContent3, null),
       null,
+    );
+  });
+  test('Codec Registration', () async {
+    final contentSerdes = ContentSerdes();
+
+    expect(
+      contentSerdes.supportedMediaTypes,
+      ['application/json', 'application/cbor'],
+    );
+
+    expect(
+      contentSerdes.offeredMediaTypes,
+      ['application/json', 'application/cbor'],
+    );
+
+    expect(
+      () => contentSerdes.addOfferedMediaType('application/xml'),
+      throwsArgumentError,
+    );
+
+    contentSerdes.addOfferedMediaType('application/td+json; charset=utf-8');
+
+    expect(
+      contentSerdes.offeredMediaTypes,
+      [
+        'application/json',
+        'application/cbor',
+        'application/td+json; charset=utf-8',
+      ],
+    );
+
+    contentSerdes.removeOfferedMediaType('application/json');
+
+    expect(
+      contentSerdes.offeredMediaTypes,
+      [
+        'application/cbor',
+        'application/td+json; charset=utf-8',
+      ],
+    );
+
+    contentSerdes
+      ..assignCodec('application/xml', JsonCodec())
+      ..addOfferedMediaType('application/xml');
+
+    expect(
+      contentSerdes.offeredMediaTypes,
+      [
+        'application/cbor',
+        'application/td+json; charset=utf-8',
+        'application/xml',
+      ],
+    );
+
+    expect(
+      () => contentSerdes.assignCodec('foo', JsonCodec()),
+      throwsArgumentError,
     );
   });
 }


### PR DESCRIPTION
This PR simplifies the system used for assigning content types to codecs. The new system does not require a manual assignment anymore, but determines the Codec that is supposed to be used by using a simple algorithm, using both the primary and the "main" subtype (e.g., `json` or `cbor`) for the assignment.