### PR TITLE
refactor!: rework internal Discovery API and CoAP Binding

### DIFF
--- a/lib/src/binding_coap/coap_client.dart
+++ b/lib/src/binding_coap/coap_client.dart
@@ -5,10 +5,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import 'dart:async';
-import 'dart:convert';
 
 import 'package:coap/coap.dart' as coap;
 import 'package:coap/config/coap_config_default.dart';
+import 'package:typed_data/typed_buffers.dart';
 
 import '../core/content.dart';
 import '../core/credentials/psk_credentials.dart';
@@ -18,8 +18,6 @@ import '../core/security_provider.dart';
 import '../core/thing_discovery.dart';
 import '../definitions/form.dart';
 import '../definitions/operation_type.dart';
-import '../definitions/security/psk_security_scheme.dart';
-import '../definitions/thing_description.dart';
 import '../scripting_api/subscription.dart';
 import 'coap_binding_exception.dart';
 import 'coap_config.dart';
@@ -41,7 +39,7 @@ class _InternalCoapConfig extends CoapConfigDefault {
       return;
     }
 
-    if (_usesPskScheme(form) && coapConfig.useTinyDtls) {
+    if (form.usesPskScheme && coapConfig.useTinyDtls) {
       dtlsBackend = coap.DtlsBackend.TinyDtls;
     } else if (coapConfig.useOpenSsl) {
       dtlsBackend = coap.DtlsBackend.OpenSsl;
@@ -59,176 +57,33 @@ class _InternalCoapConfig extends CoapConfigDefault {
   bool get _dtlsNeeded => _form?.resolvedHref.scheme == 'coaps';
 }
 
-bool _usesPskScheme(Form form) {
-  return form.securityDefinitions.whereType<PskSecurityScheme>().isNotEmpty;
-}
+coap.PskCredentialsCallback? _createPskCallback(
+  Uri uri,
+  Form? form,
+  ClientSecurityProvider? clientSecurityProvider,
+) {
+  final usesPskScheme = form?.usesPskScheme ?? false;
+  final pskCredentialsCallback = clientSecurityProvider?.pskCredentialsCallback;
 
-class _CoapRequest {
-  /// Creates a new [_CoapRequest]
-  _CoapRequest(
-    this._form,
-    this._requestMethod,
-    CoapConfig _coapConfig,
-    ClientSecurityProvider? _clientSecurityProvider, [
-    this._subprotocol,
-  ])  : _coapClient = coap.CoapClient(
-          _form.resolvedHref,
-          _InternalCoapConfig(_coapConfig, _form),
-          pskCredentialsCallback:
-              _createPskCallback(_form, _clientSecurityProvider),
-        ),
-        _requestUri = _form.resolvedHref;
-
-  /// The [CoapClient] which sends out request messages.
-  final coap.CoapClient _coapClient;
-
-  /// The [Uri] describing the endpoint for the request.
-  final Uri _requestUri;
-
-  /// A reference to the [Form] that is the basis for this request.
-  final Form _form;
-
-  /// The [CoapRequestMethod] used in the request message (e. g.
-  /// [CoapRequestMethod.get] or [CoapRequestMethod.post]).
-  final CoapRequestMethod _requestMethod;
-
-  /// The subprotocol that should be used for requests.
-  final CoapSubprotocol? _subprotocol;
-
-  // TODO(JKRhb): blockwise parameters cannot be handled at the moment due to
-  //              limitations of the CoAP library
-  Future<coap.CoapResponse> _makeRequest(
-    String? payload, {
-    int format = coap.CoapMediaType.textPlain,
-    int accept = coap.CoapMediaType.textPlain,
-    int? block1Size,
-    int? block2Size,
-  }) async {
-    final coap.CoapResponse? response;
-    switch (_requestMethod) {
-      case CoapRequestMethod.get:
-        response = await _coapClient.get(
-          _requestUri.path,
-          earlyBlock2Negotiation: true,
-          accept: accept,
-        );
-        break;
-      case CoapRequestMethod.post:
-        response = await _coapClient.post(
-          _requestUri.path,
-          payload: payload ?? '',
-          format: format,
-        );
-        break;
-      case CoapRequestMethod.put:
-        response = await _coapClient.put(
-          _requestUri.path,
-          payload: payload ?? '',
-          format: format,
-        );
-        break;
-      case CoapRequestMethod.delete:
-        response = await _coapClient.delete(_requestUri.path);
-        break;
-      default:
-        throw UnimplementedError(
-          'CoAP request method $_requestMethod is not supported yet.',
-        );
-    }
-    _coapClient.close();
-    if (response == null) {
-      throw CoapBindingException('Sending CoAP request to $_requestUri failed');
-    }
-    return response;
+  if (!usesPskScheme || pskCredentialsCallback == null) {
+    return null;
   }
 
-  static coap.PskCredentialsCallback? _createPskCallback(
-    Form form,
-    ClientSecurityProvider? clientSecurityProvider,
-  ) {
-    final pskCredentialsCallback =
-        clientSecurityProvider?.pskCredentialsCallback;
-    if (!_usesPskScheme(form) || pskCredentialsCallback == null) {
-      return null;
-    }
+  return (identityHint) {
+    final PskCredentials? pskCredentials =
+        pskCredentialsCallback(uri, form, identityHint);
 
-    return (identityHint) {
-      final PskCredentials? pskCredentials =
-          pskCredentialsCallback(form.resolvedHref, form, identityHint);
-
-      if (pskCredentials == null) {
-        throw CoapBindingException(
-          'Missing PSK credentials for CoAPS request!',
-        );
-      }
-
-      return coap.PskCredentials(
-        identity: pskCredentials.identity,
-        preSharedKey: pskCredentials.preSharedKey,
+    if (pskCredentials == null) {
+      throw CoapBindingException(
+        'Missing PSK credentials for CoAPS request!',
       );
-    };
-  }
+    }
 
-  // TODO(JKRhb): Revisit name of this method
-  Future<Content> resolveInteraction(String? payload) async {
-    final response = await _makeRequest(
-      payload,
-      format: _form.format,
-      accept: _form.accept,
-      block1Size: _form.block1Size,
-      block2Size: _form.block2Size,
+    return coap.PskCredentials(
+      identity: pskCredentials.identity,
+      preSharedKey: pskCredentials.preSharedKey,
     );
-    final type = coap.CoapMediaType.name(response.contentFormat);
-    final body = _getPayloadFromResponse(response);
-    return Content(type, body);
-  }
-
-  Future<CoapSubscription> startObservation(
-    void Function(Content content) next,
-    void Function() complete,
-  ) async {
-    void handleResponse(coap.CoapResponse? response) {
-      if (response == null) {
-        return;
-      }
-
-      final type = coap.CoapMediaType.name(response.contentFormat);
-      final body = _getPayloadFromResponse(response);
-      final content = Content(type, body);
-      next(content);
-    }
-
-    final requestContentFormat = _form.format;
-
-    if (_subprotocol == CoapSubprotocol.observe) {
-      final request = _requestMethod.generateRequest()
-        ..contentFormat = requestContentFormat;
-      final observeClientRelation = await _coapClient.observe(request);
-      observeClientRelation.stream.listen((event) {
-        handleResponse(event.resp);
-      });
-      return CoapSubscription(_coapClient, observeClientRelation, complete);
-    }
-
-    final response = await _makeRequest(null, format: requestContentFormat);
-    handleResponse(response);
-    return CoapSubscription(_coapClient, null, complete);
-  }
-
-  /// Aborts the request and closes the client.
-  ///
-  // TODO(JKRhb): Check if this is actually enough
-  void abort() {
-    _coapClient.close();
-  }
-}
-
-Stream<List<int>> _getPayloadFromResponse(coap.CoapResponse response) {
-  if (response.payload != null) {
-    return Stream.value(response.payload!);
-  } else {
-    return const Stream.empty();
-  }
+  };
 }
 
 /// A [ProtocolClient] for the Constrained Application Protocol (CoAP).
@@ -236,52 +91,110 @@ class CoapClient extends ProtocolClient {
   /// Creates a new [CoapClient] based on an optional [CoapConfig].
   CoapClient([this._coapConfig, this._clientSecurityProvider]);
 
-  final List<_CoapRequest> _pendingRequests = [];
   final CoapConfig? _coapConfig;
 
   final ClientSecurityProvider? _clientSecurityProvider;
 
-  _CoapRequest _createRequest(Form form, OperationType operationType) {
-    final requestMethod =
-        CoapRequestMethod.fromForm(form) ?? operationType.requestMethod;
-    final CoapSubprotocol? subprotocol =
-        form.coapSubprotocol ?? operationType.subprotocol;
-    final coapConfig = _coapConfig ?? CoapConfig();
-    final request = _CoapRequest(
-      form,
-      requestMethod,
-      coapConfig,
-      _clientSecurityProvider,
-      subprotocol,
-    );
-    _pendingRequests.add(request);
-    return request;
+  Future<coap.CoapRequest> _createRequest(
+    int code,
+    Uri uri, {
+    Content? content,
+    int? format,
+    int? accept,
+    int? block1Size,
+    int? block2Size,
+  }) async {
+    if (!coap.CoapCode.isRequest(code)) {
+      throw CoapBindingException(
+        '$code is not a valid request method code.',
+      );
+    }
+
+    final payload = Uint8Buffer();
+    if (content != null) {
+      payload.addAll((await content.byteBuffer).asUint8List());
+    }
+
+    return coap.CoapRequest(code)
+      ..payload = payload
+      ..uriPath = uri.path
+      ..accept = accept ?? coap.CoapMediaType.undefined
+      ..contentFormat = format ?? coap.CoapMediaType.undefined;
   }
 
-  Future<String> _getInputFromContent(Content content) async {
-    final inputBuffer = await content.byteBuffer;
-    return utf8.decoder
-        .convert(inputBuffer.asUint8List().toList(growable: false));
+  Future<Content> _sendRequestFromForm(
+    Form form,
+    OperationType operationType, [
+    Content? content,
+  ]) async {
+    final requestMethod =
+        CoapRequestMethod.fromForm(form) ?? operationType.requestMethod;
+    final code = requestMethod.code;
+
+    return _sendRequest(
+      form.resolvedHref,
+      code,
+      content: content,
+      format: form.format,
+      accept: form.accept,
+      form: form,
+    );
+  }
+
+  // TODO(JKRhb): blockwise parameters cannot be handled at the moment due to
+  //              limitations of the CoAP library
+  Future<Content> _sendRequest(
+    Uri uri,
+    int method, {
+    Content? content,
+    required Form? form,
+    int? format,
+    int? accept,
+    int? block1Size,
+    int? block2Size,
+    coap.CoapMulticastResponseHandler? multicastResponseHandler,
+  }) async {
+    final coapClient = coap.CoapClient(
+      uri,
+      _InternalCoapConfig(_coapConfig ?? CoapConfig(), form),
+      pskCredentialsCallback:
+          _createPskCallback(uri, form, _clientSecurityProvider),
+    );
+
+    final request = await _createRequest(
+      method,
+      uri,
+      content: content,
+      format: format,
+      accept: accept,
+      block1Size: block1Size,
+      block2Size: block2Size,
+    );
+
+    final response = await coapClient.send(
+      request,
+      onMulticastResponse: multicastResponseHandler,
+    );
+    coapClient.close();
+    if (response == null) {
+      throw CoapBindingException('Sending CoAP request to $uri failed');
+    }
+    return response.content;
   }
 
   @override
   Future<Content> readResource(Form form) async {
-    final request = _createRequest(form, OperationType.readproperty);
-    return request.resolveInteraction(null);
+    return _sendRequestFromForm(form, OperationType.readproperty);
   }
 
   @override
   Future<void> writeResource(Form form, Content content) async {
-    final request = _createRequest(form, OperationType.writeproperty);
-    final input = await _getInputFromContent(content);
-    await request.resolveInteraction(input);
+    await _sendRequestFromForm(form, OperationType.writeproperty, content);
   }
 
   @override
   Future<Content> invokeResource(Form form, Content content) async {
-    final request = _createRequest(form, OperationType.invokeaction);
-    final input = await _getInputFromContent(content);
-    return request.resolveInteraction(input);
+    return _sendRequestFromForm(form, OperationType.invokeaction, content);
   }
 
   @override
@@ -300,9 +213,51 @@ class CoapClient extends ProtocolClient {
       ),
     );
 
-    final request = _createRequest(form, operationType);
+    return _startObservation(form, operationType, next, complete);
+  }
 
-    return request.startObservation(next, complete);
+  Future<CoapSubscription> _startObservation(
+    Form form,
+    OperationType operationType,
+    void Function(Content content) next,
+    void Function() complete,
+  ) async {
+    void handleResponse(coap.CoapResponse? response) {
+      if (response == null) {
+        return;
+      }
+
+      next(response.content);
+    }
+
+    final requestMethod =
+        (CoapRequestMethod.fromForm(form) ?? CoapRequestMethod.get).code;
+
+    final request = await _createRequest(
+      requestMethod,
+      form.resolvedHref,
+      format: form.format,
+      accept: form.accept,
+    );
+
+    final subprotocol = form.coapSubprotocol ?? operationType.subprotocol;
+
+    final coapClient = coap.CoapClient(
+      form.resolvedHref,
+      _InternalCoapConfig(_coapConfig ?? CoapConfig(), form),
+    );
+
+    if (subprotocol == CoapSubprotocol.observe) {
+      final observeClientRelation = await coapClient.observe(request);
+      observeClientRelation.stream.listen((event) {
+        handleResponse(event.resp);
+      });
+      return CoapSubscription(coapClient, observeClientRelation, complete);
+    }
+
+    final response = await coapClient.send(request);
+    handleResponse(response);
+    return CoapSubscription(coapClient, null, complete);
   }
 
   @override
@@ -311,40 +266,18 @@ class CoapClient extends ProtocolClient {
   }
 
   @override
-  Future<void> stop() async {
-    for (final request in _pendingRequests) {
-      request.abort();
-    }
-    _pendingRequests.clear();
-  }
+  Future<void> stop() async {}
 
-  ThingDescription _handleDiscoveryResponse(
-    coap.CoapResponse? response,
-    Uri uri,
-  ) {
-    final rawThingDescription = response?.payloadString;
-
-    if (response == null) {
-      throw DiscoveryException('Direct CoAP Discovery from $uri failed!');
-    }
-
-    return ThingDescription(rawThingDescription);
-  }
-
-  Stream<ThingDescription> _discoverFromMulticast(
+  Stream<Content> _discoverFromMulticast(
     coap.CoapClient client,
     Uri uri,
   ) async* {
     // TODO(JKRhb): This method currently does not work with block-wise transfer
     //               due to a bug in the CoAP library.
-    final streamController = StreamController<ThingDescription>();
-    final request = coap.CoapRequest(coap.CoapCode.get, confirmable: false)
-      ..uriPath = uri.path
-      ..accept = coap.CoapMediaType.applicationTdJson;
+    final streamController = StreamController<Content>();
     final multicastResponseHandler = coap.CoapMulticastResponseHandler(
       (data) {
-        final thingDescription = _handleDiscoveryResponse(data.resp, uri);
-        streamController.add(thingDescription);
+        streamController.add(data.resp.content);
       },
       onError: streamController.addError,
       onDone: () async {
@@ -352,35 +285,31 @@ class CoapClient extends ProtocolClient {
       },
     );
 
-    final response =
-        client.send(request, onMulticastResponse: multicastResponseHandler);
-    unawaited(response);
-    unawaited(
-      Future.delayed(
-          _coapConfig?.multicastDiscoveryTimeout ?? const Duration(seconds: 20),
-          () {
-        client
-          ..cancel(request)
-          ..close();
-      }),
+    final content = _sendRequest(
+      uri,
+      coap.CoapCode.get,
+      form: null,
+      accept: coap.CoapMediaType.applicationTdJson,
+      multicastResponseHandler: multicastResponseHandler,
     );
+    unawaited(content);
     yield* streamController.stream;
   }
 
-  Stream<ThingDescription> _discoverFromUnicast(
+  Stream<Content> _discoverFromUnicast(
     coap.CoapClient client,
     Uri uri,
   ) async* {
-    final response = await client.get(
-      uri.path,
+    yield await _sendRequest(
+      uri,
+      coap.CoapCode.get,
+      form: null,
       accept: coap.CoapMediaType.applicationTdJson,
     );
-    client.close();
-    yield _handleDiscoveryResponse(response, uri);
   }
 
   @override
-  Stream<ThingDescription> discoverDirectly(
+  Stream<Content> discoverDirectly(
     Uri uri, {
     bool disableMulticast = false,
   }) async* {
@@ -396,30 +325,9 @@ class CoapClient extends ProtocolClient {
     }
   }
 
-  @override
-  Stream<Uri> discoverWithCoreLinkFormat(Uri uri) async* {
-    final discoveryUri = createCoreLinkFormatDiscoveryUri(uri);
-    final coapConfig = _coapConfig ?? CoapConfig();
-
-    final coapClient =
-        coap.CoapClient(discoveryUri, _InternalCoapConfig(coapConfig, null));
-
-    // TODO(JKRhb): Multicast could be supported here as well.
-    final request = coap.CoapRequest(coap.CoapCode.get)
-      ..uriPath = discoveryUri.path
-      ..accept = coap.CoapMediaType.applicationLinkFormat;
-    final response = await coapClient.send(request);
-
-    coapClient.close();
-
-    if (response == null) {
-      throw DiscoveryException(
-        'Got no CoRE Link Format Discovery response for $uri',
-      );
-    }
-
-    final actualContentFormat = response.contentFormat;
-    const expectedContentFormat = coap.CoapMediaType.applicationLinkFormat;
+  Content _handleCoreLinkFormatContent(Content content) {
+    final actualContentFormat = content.type;
+    const expectedContentFormat = 'application/link-format';
 
     if (actualContentFormat != expectedContentFormat) {
       throw DiscoveryException(
@@ -429,14 +337,41 @@ class CoapClient extends ProtocolClient {
       );
     }
 
-    final payloadString = response.payloadString;
+    return content;
+  }
 
-    if (payloadString == null) {
-      throw DiscoveryException(
-        'Received empty payload for CoRE Link Format Discovery from $uri',
+  @override
+  Stream<Content> discoverWithCoreLinkFormat(Uri uri) async* {
+    final discoveryUri = createCoreLinkFormatDiscoveryUri(uri);
+    coap.CoapMulticastResponseHandler? multicastResponseHandler;
+    final streamController = StreamController<Content>();
+
+    if (uri.isMulticastAddress) {
+      multicastResponseHandler = coap.CoapMulticastResponseHandler(
+        (data) {
+          final handledContent =
+              _handleCoreLinkFormatContent(data.resp.content);
+          streamController.add(handledContent);
+        },
+        onError: streamController.addError,
+        onDone: () async {
+          await streamController.close();
+        },
       );
     }
 
-    yield* Stream.fromIterable(parseCoreLinkFormat(payloadString, uri));
+    final content = await _sendRequest(
+      discoveryUri,
+      coap.CoapCode.get,
+      form: null,
+      accept: coap.CoapMediaType.applicationLinkFormat,
+      multicastResponseHandler: multicastResponseHandler,
+    );
+
+    if (uri.isMulticastAddress) {
+      yield* streamController.stream;
+    } else {
+      yield _handleCoreLinkFormatContent(content);
+    }
   }
 }

--- a/lib/src/binding_coap/coap_extensions.dart
+++ b/lib/src/binding_coap/coap_extensions.dart
@@ -2,8 +2,10 @@ import 'dart:io';
 
 import 'package:coap/coap.dart';
 
+import '../core/content.dart';
 import '../definitions/form.dart';
 import '../definitions/operation_type.dart';
+import '../definitions/security/psk_security_scheme.dart';
 import 'coap_definitions.dart';
 
 const _validBlockwiseValues = [16, 32, 64, 128, 256, 512, 1024];
@@ -19,6 +21,10 @@ extension InternetAddressMethods on Uri {
 
 /// CoAP-specific extensions for the [Form] class.
 extension CoapFormExtension on Form {
+  /// Determines if this [Form] supports the [PskSecurityScheme].
+  bool get usesPskScheme =>
+      securityDefinitions.whereType<PskSecurityScheme>().isNotEmpty;
+
   /// Get the [CoapSubprotocol] for this [Form], if one is set.
   CoapSubprotocol? get coapSubprotocol {
     if (subprotocol == coapPrefixMapping.expandCurieString('observe')) {
@@ -117,5 +123,31 @@ extension OperationTypeExtension on OperationType {
     }
 
     return null;
+  }
+}
+
+/// Extension for easily extracting the [content] from a [CoapResponse].
+extension ResponseExtension on CoapResponse {
+  Stream<List<int>> get _payloadStream {
+    final payload = this.payload;
+    if (payload != null) {
+      return Stream.value(payload);
+    } else {
+      return const Stream.empty();
+    }
+  }
+
+  String get _contentType {
+    // FIXME: Replace once new CoAP library version has been released.
+    if (contentFormat == CoapMediaType.undefined) {
+      return 'application/json';
+    }
+
+    return CoapMediaType.name(contentFormat);
+  }
+
+  /// Extract the [Content] of this [CoapResponse].
+  Content get content {
+    return Content(_contentType, _payloadStream);
   }
 }

--- a/lib/src/core/protocol_interfaces/protocol_client.dart
+++ b/lib/src/core/protocol_interfaces/protocol_client.dart
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import '../../definitions/form.dart';
-import '../../definitions/thing_description.dart';
 import '../../scripting_api/subscription.dart';
 import '../content.dart';
 
@@ -17,17 +16,19 @@ abstract class ProtocolClient {
   /// Stops this [ProtocolClient].
   Future<void> stop();
 
-  /// Discovers a [ThingDescription] from a [uri].
+  /// Discovers one or more Thing Descriptions from a [uri], returning a
+  /// [Stream] of [Content].
   ///
   /// Allows the caller to explicitly [disableMulticast], overriding the
   /// multicast settings in the config of the underlying binding implementation.
-  Stream<ThingDescription> discoverDirectly(
+  Stream<Content> discoverDirectly(
     Uri uri, {
     bool disableMulticast = false,
   });
 
-  /// Discovers [ThingDescription] links from a [uri] using the CoRE Link
-  /// Format and Web Linking (see [RFC 6690]).
+  /// Discovers one or more Thing Descriptions from a [uri] using the CoRE Link
+  /// Format and Web Linking (see [RFC 6690]), returning a [Stream] of
+  /// [Content].
   ///
   /// The [uri] must point to either the resource lookup interface of a CoRE
   /// Resource Directory (see [RFC 9176]) or to a CoRE Resource Discovery
@@ -39,7 +40,7 @@ abstract class ProtocolClient {
   ///
   /// [RFC 9176]: https://datatracker.ietf.org/doc/html/rfc9176
   /// [RFC 6690]: https://datatracker.ietf.org/doc/html/rfc6690
-  Stream<Uri> discoverWithCoreLinkFormat(Uri uri);
+  Stream<Content> discoverWithCoreLinkFormat(Uri uri);
 
   /// Requests the client to perform a `readproperty` operation on a [form].
   Future<Content> readResource(Form form);


### PR DESCRIPTION
This PR reworks the internal Discovery API, separating the different library modules more cleanly and allowing the addition of further TD Media Types (such as CBOR or XML) in the future. The PR also greatly improves the CoAP binding, potentially allowing for secure discovery using ACE-OAuth as a follow-up (see #6).