### PR TITLE
feat: improve `ThingDescriptionValidationException`

### DIFF
--- a/lib/src/definitions/thing_description.dart
+++ b/lib/src/definitions/thing_description.dart
@@ -47,7 +47,10 @@ class ThingDescription {
     if (validate) {
       final validationResult = thingDescriptionSchema.validate(json);
       if (!validationResult.isValid) {
-        throw ThingDescriptionValidationException(json);
+        throw ThingDescriptionValidationException(
+          json,
+          validationResult.errors,
+        );
       }
     }
     _parseJson(json);

--- a/lib/src/definitions/validation/thing_description_schema.dart
+++ b/lib/src/definitions/validation/thing_description_schema.dart
@@ -15,11 +15,21 @@ final thingDescriptionSchema = JsonSchema.create(_rawThingDescriptionSchema);
 /// invalid.
 class ThingDescriptionValidationException extends ValidationException {
   /// Constructor.
-  ThingDescriptionValidationException(this.rawThingDescription)
-      : super('Validation of Thing Description failed.');
+  ThingDescriptionValidationException(
+    this.rawThingDescription,
+    this._validationErrors,
+  ) : super('Validation of Thing Description failed');
+
+  final List<ValidationError> _validationErrors;
 
   /// The raw Thing Description that is invalid.
   Map<String, dynamic> rawThingDescription;
+
+  @override
+  String toString() {
+    return 'ThingDescriptionValidationException: $message.\n\n'
+        'Errors:\n\n ${_validationErrors.join("\n")}';
+  }
 }
 
 final Map<String, dynamic> _rawThingDescriptionSchema = <String, dynamic>{


### PR DESCRIPTION
Calling `toString()` on the `ThingDescriptionValidationException` now returns a formatted list of all validation errors.