### PR TITLE
feat!: allow passing invalid credentials to security callbacks

### DIFF
--- a/example/complex_example.dart
+++ b/example/complex_example.dart
@@ -101,7 +101,11 @@ final Map<String, BasicCredentials> basicCredentials = {
   'urn:test': BasicCredentials('username', 'password')
 };
 
-Future<BasicCredentials?> basicCredentialsCallback(Uri uri, Form? form) async {
+Future<BasicCredentials?> basicCredentialsCallback(
+  Uri uri,
+  Form? form, [
+  BasicCredentials? invalidCredentials,
+]) async {
   final id = form?.interactionAffordance.thingDescription.identifier;
 
   return basicCredentials[id];

--- a/example/http_basic_authentication.dart
+++ b/example/http_basic_authentication.dart
@@ -51,7 +51,11 @@ final Map<String, BasicCredentials> basicCredentialsMap = {
   'urn:test': basicCredentials
 };
 
-Future<BasicCredentials?> basicCredentialsCallback(Uri uri, Form? form) async {
+Future<BasicCredentials?> basicCredentialsCallback(
+  Uri uri,
+  Form? form,
+  BasicCredentials? invalidCredentials,
+) async {
   if (form == null) {
     return basicCredentials;
   }

--- a/lib/src/binding_http/http_client.dart
+++ b/lib/src/binding_http/http_client.dart
@@ -209,12 +209,22 @@ class HttpClient extends ProtocolClient {
     return _handleResponse(request, response, form);
   }
 
-  Future<BasicCredentials?> _getBasicCredentials(Uri uri, Form? form) async {
-    return _clientSecurityProvider?.basicCredentialsCallback?.call(uri, form);
+  Future<BasicCredentials?> _getBasicCredentials(
+    Uri uri,
+    Form? form, [
+    BasicCredentials? invalidCredentials,
+  ]) async {
+    return _clientSecurityProvider?.basicCredentialsCallback
+        ?.call(uri, form, invalidCredentials);
   }
 
-  Future<BearerCredentials?> _getBearerCredentials(Uri uri, Form? form) async {
-    return _clientSecurityProvider?.bearerCredentialsCallback?.call(uri, form);
+  Future<BearerCredentials?> _getBearerCredentials(
+    Uri uri,
+    Form? form, [
+    BearerCredentials? invalidCredentials,
+  ]) async {
+    return _clientSecurityProvider?.bearerCredentialsCallback
+        ?.call(uri, form, invalidCredentials);
   }
 
   static Map<String, String> _getHeadersFromForm(Form form) {

--- a/lib/src/core/security_provider.dart
+++ b/lib/src/core/security_provider.dart
@@ -39,10 +39,14 @@ typedef ClientPskCallback = PskCredentials? Function(
 /// will lead to the throw of an exception in the respective binding). This
 /// behavior might change in future versions of `dart_wot`.
 ///
+/// If the authorization/authentication fails with the given credentials, the
+/// callback will be invoked again, containing the [invalidCredentials] as a set
+/// argument.
+///
 /// This callback signature is currently only used for [PskCredentials] due to
 /// implementation limititations, which do not allow for asynchronous callbacks.
 typedef AsyncClientSecurityCallback<T extends Credentials> = Future<T?>
-    Function(Uri uri, Form? form);
+    Function(Uri uri, Form? form, T? invalidCredentials);
 
 /// Class for providing callbacks for client [Credentials] at runtime.
 ///

--- a/test/binding_http/http_test.dart
+++ b/test/binding_http/http_test.dart
@@ -116,12 +116,12 @@ void main() {
       };
 
       final clientSecurityProvider = ClientSecurityProvider(
-        basicCredentialsCallback: (uri, form) async {
+        basicCredentialsCallback: (uri, form, [invalidCredentials]) async {
           return basicCredentialsStore[uri.host];
         },
-        digestCredentialsCallback: (uri, form) async =>
+        digestCredentialsCallback: (uri, form, [invalidCredentials]) async =>
             digestCredentialsStore[uri.host],
-        bearerCredentialsCallback: (uri, form) async =>
+        bearerCredentialsCallback: (uri, form, [invalidCredentials]) async =>
             bearerCredentialsStore[uri.host],
       );
 


### PR DESCRIPTION
Passing invalid Credentials after a failed authorization/authentication process allows users to try again with different credentials, once it is supported by the binding implementations.