### PR TITLE
fix(binding-coap): improve reponse error handling

### DIFF
--- a/lib/src/binding_coap/coap_binding_exception.dart
+++ b/lib/src/binding_coap/coap_binding_exception.dart
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:coap/coap.dart';
+
 /// This [Exception] is thrown when an error within the CoAP Binding occurs.
 class CoapBindingException implements Exception {
   /// Constructor.
@@ -18,4 +20,31 @@ class CoapBindingException implements Exception {
   String toString() {
     return 'CoapBindingException: $_message';
   }
+}
+
+/// Base class for [Exception]s that are thrown due to error responses.
+abstract class CoapBindingResponseException extends CoapBindingException {
+  /// Constructor.
+  CoapBindingResponseException(CoapResponse response)
+      : super(
+          '${response.statusCodeString}. Payload: ${response.payloadString}',
+        );
+}
+
+/// [Exception] that is thrown if a client error occurs.
+class CoapClientErrorException extends CoapBindingResponseException {
+  /// Constructor.
+  CoapClientErrorException(super.response);
+
+  @override
+  String toString() => 'CoapClientErrorException: $_message';
+}
+
+/// [Exception] that is thrown if a server error occurs.
+class CoapServerErrorException extends CoapBindingResponseException {
+  /// Constructor.
+  CoapServerErrorException(super.response);
+
+  @override
+  String toString() => 'CoapServerErrorException: $_message';
 }

--- a/lib/src/binding_coap/coap_client.dart
+++ b/lib/src/binding_coap/coap_client.dart
@@ -193,6 +193,7 @@ class CoapClient extends ProtocolClient {
     }
 
     coapClient.close();
+    response.checkResponseCode();
     return response.content;
   }
 

--- a/lib/src/binding_coap/coap_client.dart
+++ b/lib/src/binding_coap/coap_client.dart
@@ -316,12 +316,8 @@ class CoapClient extends ProtocolClient {
       return response;
     }
 
-    final errorString = '${response.code}. Payload: ${response.payloadString}';
-
     if (response.code.isServerError) {
-      throw CoapBindingException(
-        'Server error: $errorString',
-      );
+      throw CoapServerErrorException(response);
     }
 
     final aceCreationHint = response.creationHint;
@@ -341,9 +337,7 @@ class CoapClient extends ProtocolClient {
       }
     }
 
-    throw CoapBindingException(
-      'Client error: $errorString',
-    );
+    throw CoapClientErrorException(response);
   }
 
   @override

--- a/lib/src/binding_coap/coap_extensions.dart
+++ b/lib/src/binding_coap/coap_extensions.dart
@@ -153,6 +153,18 @@ extension ResponseExtension on CoapResponse {
     return Content(_contentType, _payloadStream);
   }
 
+  /// Checks the [code] of this [CoapResponse] and throws an [Exception] if it
+  /// should indicate an error.
+  void checkResponseCode() {
+    if (code.isServerError) {
+      throw CoapServerErrorException(this);
+    }
+
+    if (code.isErrorResponse) {
+      throw CoapClientErrorException(this);
+    }
+  }
+
   /// Validates the payload and returns a serialized ACE creation hint if
   /// successful.
   AuthServerRequestCreationHint? get creationHint {


### PR DESCRIPTION
I noticed that the CoAP binding is not handling error responses correctly at the moment. This PR applies some refactoring and introduces an additional check for error responses.