### PR TITLE
feat: implement initial DNS-SD support

### DIFF
--- a/example/coap_dns_sd_discovery.dart
+++ b/example/coap_dns_sd_discovery.dart
@@ -1,0 +1,48 @@
+// Copyright 2023 The NAMIB Project Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+// ignore_for_file: avoid_print
+
+import 'package:dart_wot/dart_wot.dart';
+
+const propertyName = 'string';
+
+extension PrintExtension on InteractionOutput {
+  Future<void> printValue() async {
+    print(await value());
+  }
+}
+
+void handleThingDescription(ThingDescription thingDescription) =>
+    print('Discovered TD with title "${thingDescription.title}".');
+
+Future<void> main(List<String> args) async {
+  final servient = Servient()..addClientFactory(CoapClientFactory());
+
+  final wot = await servient.start();
+  final uri = Uri.parse('_wot._udp.local');
+
+  // Example using for-await-loop
+  try {
+    await for (final thingDescription
+        in wot.discover(uri, method: DiscoveryMethod.dnsServiceDiscovery)) {
+      handleThingDescription(thingDescription);
+    }
+    print('Discovery with "await for" has finished.');
+  } on Exception catch (error) {
+    print(error);
+  }
+
+  // Example using the .listen() method, allowing for error handling
+  //
+  // Notice how the "onDone" callback is called before the result is passed
+  // to the handleThingDescription function.
+  wot.discover(uri, method: DiscoveryMethod.dnsServiceDiscovery).listen(
+        handleThingDescription,
+        onError: (error) => print('Encountered an error: $error'),
+        onDone: () => print('Discovery with "listen" has finished.'),
+      );
+}

--- a/lib/src/scripting_api/discovery/discovery_method.dart
+++ b/lib/src/scripting_api/discovery/discovery_method.dart
@@ -35,4 +35,15 @@ enum DiscoveryMethod {
   ///
   /// [RFC 9176]: https://datatracker.ietf.org/doc/html/rfc9176
   coreResourceDirectory,
+
+  /// Discovery using DNS-Based Service Discovery (DNS-SD, [RFC 6763].
+  ///
+  /// Currently, only Multicast DNS (mDNS, [RFC 6762]) for discovery on the same
+  /// network is supported.
+  /// Futhermore, discovery using this method currently does not work on Windows
+  /// due to limitations in the `multicast_dns` package.
+  ///
+  /// [RFC 6762]: https://www.rfc-editor.org/rfc/rfc6762
+  /// [RFC 6763]: https://www.rfc-editor.org/rfc/rfc6763
+  dnsServiceDiscovery,
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,6 +27,7 @@ dependencies:
   json_schema3: ^1.0.0
   meta: ^1.8.0
   mqtt_client: ^9.7.4
+  multicast_dns: ^0.3.2+1
   typed_data: ^1.3.0
   uri: ^1.0.0
   uuid: ^3.0.7


### PR DESCRIPTION
This PR includes a first approach to supporting DNS-DS discovery, as specified in [section 6.3](https://w3c.github.io/wot-discovery/#introduction-dns-sd-sec) of the WoT Discovery specification.

For now, only discovery using mDNS is supported.