### PR TITLE
fix: correctly parse String `@context` entries

### DIFF
--- a/lib/src/definitions/context_entry.dart
+++ b/lib/src/definitions/context_entry.dart
@@ -35,8 +35,8 @@ class ContextEntry {
     if (json is String) {
       if (firstEntry && _validTdContextValues.contains(json)) {
         prefixMapping.defaultPrefixValue = json;
-        return ContextEntry(json, null);
       }
+      return ContextEntry(json, null);
     }
 
     if (json is Map<String, dynamic>) {


### PR DESCRIPTION
This PR fixes a small bug that was introduced by #28, causing errors when encountering a string-based @context entry after the first one.