### PR TITLE
Refactor and fix data schemas and TD parsing

### DIFF
--- a/example/complex_example.dart
+++ b/example/complex_example.dart
@@ -106,7 +106,7 @@ Future<BasicCredentials?> basicCredentialsCallback(
   Form? form, [
   BasicCredentials? invalidCredentials,
 ]) async {
-  final id = form?.interactionAffordance.thingDescription.identifier;
+  final id = form?.thingDescription.identifier;
 
   return basicCredentials[id];
 }

--- a/example/example.dart
+++ b/example/example.dart
@@ -17,7 +17,7 @@ Future<BasicCredentials?> basicCredentialsCallback(
   Form? form, [
   BasicCredentials? invalidCredentials,
 ]) async {
-  final id = form?.interactionAffordance.thingDescription.identifier;
+  final id = form?.thingDescription.identifier;
 
   return basicCredentials[id];
 }

--- a/example/http_basic_authentication.dart
+++ b/example/http_basic_authentication.dart
@@ -60,7 +60,7 @@ Future<BasicCredentials?> basicCredentialsCallback(
     return basicCredentials;
   }
 
-  final id = form.interactionAffordance.thingDescription.identifier;
+  final id = form.thingDescription.identifier;
 
   return basicCredentialsMap[id];
 }

--- a/lib/src/binding_mqtt/mqtt_extensions.dart
+++ b/lib/src/binding_mqtt/mqtt_extensions.dart
@@ -145,7 +145,7 @@ extension MqttFormExtension on Form {
       throw ValidationException(
         'Encountered unknown QoS value $qosValue. '
         'in form with href $href of Thing Description with Identifier '
-        '${interactionAffordance.thingDescription.identifier}.',
+        '${thingDescription.identifier}.',
       );
     }
 

--- a/lib/src/definitions/additional_expected_response.dart
+++ b/lib/src/definitions/additional_expected_response.dart
@@ -62,7 +62,7 @@ class AdditionalExpectedResponse {
   final String? schema;
 
   /// Any other additional field will be included in this [Map].
-  final Map<String, dynamic> additionalFields;
+  final Map<String, dynamic>? additionalFields;
 
   @override
   bool operator ==(Object other) {

--- a/lib/src/definitions/additional_expected_response.dart
+++ b/lib/src/definitions/additional_expected_response.dart
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import 'package:collection/collection.dart';
+import 'package:curie/curie.dart';
 import 'package:meta/meta.dart';
 
 import 'extensions/json_parser.dart';
@@ -26,6 +27,7 @@ class AdditionalExpectedResponse {
   factory AdditionalExpectedResponse.fromJson(
     Map<String, dynamic> json,
     String formContentType,
+    PrefixMapping prefixMapping,
   ) {
     final Set<String> parsedFields = {};
 
@@ -33,10 +35,8 @@ class AdditionalExpectedResponse {
         json.parseField<String>('contentType', parsedFields) ?? formContentType;
     final success = json.parseField<bool>('success', parsedFields);
     final schema = json.parseField<String>('schema', parsedFields);
-
-    final additionalFields = Map.fromEntries(
-      json.entries.where((entry) => !parsedFields.contains(entry.key)),
-    );
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
 
     return AdditionalExpectedResponse(
       contentType,

--- a/lib/src/definitions/data_schema.dart
+++ b/lib/src/definitions/data_schema.dart
@@ -80,7 +80,8 @@ class DataSchema {
     final exclusiveMaximum =
         json.parseField<num>('exclusiveMaximum', parsedFields);
     final multipleOf = json.parseField<num>('multipleOf', parsedFields);
-    final items = json.parseDataSchemaArrayField('items', prefixMapping);
+    final items =
+        json.parseDataSchemaArrayField('items', prefixMapping, parsedFields);
     final minItems = json.parseField<int>('minItems', parsedFields);
     final maxItems = json.parseField<int>('maxItems', parsedFields);
     final required = json.parseField<List<String>>('required', parsedFields);

--- a/lib/src/definitions/data_schema.dart
+++ b/lib/src/definitions/data_schema.dart
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:curie/curie.dart';
+
 import 'extensions/json_parser.dart';
 
 /// Metadata that describes the data format used. It can be used for validation.
@@ -44,51 +46,90 @@ class DataSchema {
     this.contentEncoding,
     this.contentMediaType,
     this.rawJson,
-    Map<String, dynamic>? additionalFields,
-  }) {
-    this.additionalFields.addAll(additionalFields ?? {});
-  }
+    this.additionalFields,
+  });
 
   // TODO: Consider creating separate classes for each data type.
   //       Also see https://github.com/w3c/wot-thing-description/issues/1390
 
   /// Creates a new [DataSchema] from a [json] object.
   factory DataSchema.fromJson(
-    Map<String, dynamic> json, [
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping, [
     Set<String>? parsedFields,
   ]) {
+    parsedFields = parsedFields ?? {};
+    final atType = json.parseArrayField<String>('@type', parsedFields);
+    final title = json.parseField<String>('title', parsedFields);
+    final titles = json.parseMapField<String>('titles', parsedFields);
+    final description = json.parseField<String>('description', parsedFields);
+    final descriptions =
+        json.parseMapField<String>('descriptions', parsedFields);
+    final constant = json.parseField<Object>('constant', parsedFields);
+    final defaultValue = json.parseField<Object>('default', parsedFields);
+    final enumeration = json.parseField<List<Object>>('enum', parsedFields);
+    final readOnly = json.parseField<bool>('readOnly', parsedFields);
+    final writeOnly = json.parseField<bool>('writeOnly', parsedFields);
+    final format = json.parseField<String>('format', parsedFields);
+    final unit = json.parseField<String>('unit', parsedFields);
+    final type = json.parseField<String>('type', parsedFields);
+    final minimum = json.parseField<num>('minimum', parsedFields);
+    final exclusiveMinimum =
+        json.parseField<num>('exclusiveMinimum', parsedFields);
+    final maximum = json.parseField<num>('minimum', parsedFields);
+    final exclusiveMaximum =
+        json.parseField<num>('exclusiveMaximum', parsedFields);
+    final multipleOf = json.parseField<num>('multipleOf', parsedFields);
+    final items = json.parseDataSchemaArrayField('items', prefixMapping);
+    final minItems = json.parseField<int>('minItems', parsedFields);
+    final maxItems = json.parseField<int>('maxItems', parsedFields);
+    final required = json.parseField<List<String>>('required', parsedFields);
+    final minLength = json.parseField<int>('minLength', parsedFields);
+    final maxLength = json.parseField<int>('maxLength', parsedFields);
+    final pattern = json.parseField<String>('pattern', parsedFields);
+    final contentEncoding =
+        json.parseField<String>('contentEncoding', parsedFields);
+    final contentMediaType =
+        json.parseField<String>('contentMediaType', parsedFields);
+    final oneOf =
+        json.parseDataSchemaArrayField('oneOf', prefixMapping, parsedFields);
+    final properties =
+        json.parseDataSchemaMapField('properties', prefixMapping, parsedFields);
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
+
     return DataSchema(
-      atType: json.parseArrayField<String>('@type', parsedFields),
-      title: json.parseField<String>('title', parsedFields),
-      titles: json.parseMapField<String>('titles', parsedFields),
-      description: json.parseField<String>('description', parsedFields),
-      descriptions: json.parseMapField<String>('descriptions', parsedFields),
-      constant: json.parseField<Object>('constant', parsedFields),
-      defaultValue: json.parseField<Object>('default', parsedFields),
-      enumeration: json.parseField<List<Object>>('enum', parsedFields),
-      readOnly: json.parseField<bool>('readOnly', parsedFields),
-      writeOnly: json.parseField<bool>('writeOnly', parsedFields),
-      format: json.parseField<String>('format', parsedFields),
-      unit: json.parseField<String>('unit', parsedFields),
-      type: json.parseField<String>('type', parsedFields),
-      minimum: json.parseField<num>('minimum', parsedFields),
-      exclusiveMinimum: json.parseField<num>('exclusiveMinimum', parsedFields),
-      maximum: json.parseField<num>('minimum', parsedFields),
-      exclusiveMaximum: json.parseField<num>('exclusiveMaximum', parsedFields),
-      multipleOf: json.parseField<num>('multipleOf', parsedFields),
-      items: json.parseDataSchemaArrayField('items'),
-      minItems: json.parseField<int>('minItems', parsedFields),
-      maxItems: json.parseField<int>('maxItems', parsedFields),
-      required: json.parseField<List<String>>('required', parsedFields),
-      minLength: json.parseField<int>('minLength', parsedFields),
-      maxLength: json.parseField<int>('maxLength', parsedFields),
-      pattern: json.parseField<String>('pattern', parsedFields),
-      contentEncoding: json.parseField<String>('contentEncoding', parsedFields),
-      contentMediaType:
-          json.parseField<String>('contentMediaType', parsedFields),
-      oneOf: json.parseDataSchemaArrayField('oneOf', parsedFields),
-      properties: json.parseDataSchemaMapField('properties', parsedFields),
+      atType: atType,
+      title: title,
+      titles: titles,
+      description: description,
+      descriptions: descriptions,
+      constant: constant,
+      defaultValue: defaultValue,
+      enumeration: enumeration,
+      readOnly: readOnly,
+      writeOnly: writeOnly,
+      format: format,
+      unit: unit,
+      type: type,
+      minimum: minimum,
+      exclusiveMinimum: exclusiveMinimum,
+      maximum: maximum,
+      exclusiveMaximum: exclusiveMaximum,
+      multipleOf: multipleOf,
+      items: items,
+      minItems: minItems,
+      maxItems: maxItems,
+      required: required,
+      minLength: minLength,
+      maxLength: maxLength,
+      pattern: pattern,
+      contentEncoding: contentEncoding,
+      contentMediaType: contentMediaType,
+      oneOf: oneOf,
+      properties: properties,
       rawJson: json,
+      additionalFields: additionalFields,
     );
   }
 
@@ -225,7 +266,7 @@ class DataSchema {
   final String? contentMediaType;
 
   /// Additional fields that could not be deserialized as class members.
-  final Map<String, dynamic> additionalFields = {};
+  final Map<String, dynamic>? additionalFields;
 
   /// The original JSON object that was parsed when creating this [DataSchema].
   final Map<String, dynamic>? rawJson;

--- a/lib/src/definitions/data_schema.dart
+++ b/lib/src/definitions/data_schema.dart
@@ -6,195 +6,227 @@
 
 import 'extensions/json_parser.dart';
 
-/// Parses a [json] object and adds its contents to a [dataSchema].
-void parseDataSchemaJson(DataSchema dataSchema, Map<String, dynamic> json) {
-  dataSchema
-    ..atType = json.parseArrayField<String>('@type')
-    ..title = json.parseField<String>('title')
-    ..titles = json.parseMapField<String>('titles')
-    ..description = json.parseField<String>('description')
-    ..constant = json.parseField<Object>('constant')
-    ..enumeration = json.parseField<List<Object>>('enum')
-    ..readOnly = json.parseField<bool>('readOnly') ?? dataSchema.readOnly
-    ..writeOnly = json.parseField<bool>('writeOnly') ?? dataSchema.writeOnly
-    ..format = json.parseField<String>('format')
-    ..type = json.parseField<String>('type')
-    ..minimum = json.parseField<num>('minimum')
-    ..exclusiveMinimum = json.parseField<num>('exclusiveMinimum')
-    ..maximum = json.parseField<num>('minimum')
-    ..exclusiveMaximum = json.parseField<num>('exclusiveMaximum')
-    ..multipleOf = json.parseField<num>('multipleOf')
-    ..minItems = json.parseField<int>('minItems')
-    ..maxItems = json.parseField<int>('maxItems')
-    ..required = json.parseField<List<String>>('required')
-    ..minLength = json.parseField<int>('minLength')
-    ..maxLength = json.parseField<int>('maxLength')
-    ..pattern = json.parseField<String>('pattern')
-    ..contentEncoding = json.parseField<String>('contentEncoding')
-    ..contentMediaType = json.parseField<String>('contentMediaType');
-
-  final oneOf = json['oneOf'];
-  if (oneOf is List<Map<String, dynamic>>) {
-    dataSchema.oneOf = oneOf.map(DataSchema.fromJson).toList();
-  }
-
-  final properties = json['properties'];
-  if (properties is Map<String, Map<String, dynamic>>) {
-    dataSchema.properties = Map.fromEntries(
-      properties.entries.map(
-        (entry) => MapEntry(entry.key, DataSchema.fromJson(entry.value)),
-      ),
-    );
-  }
-}
-
 /// Metadata that describes the data format used. It can be used for validation.
 ///
 /// See W3C WoT Thing Description specification, [section 5.3.2.1][spec link].
 ///
 /// [spec link]: https://w3c.github.io/wot-thing-description/#dataschema
 class DataSchema {
+  /// Constructor
+  DataSchema({
+    this.atType,
+    this.title,
+    this.titles,
+    this.description,
+    this.descriptions,
+    this.constant,
+    this.defaultValue,
+    this.unit,
+    this.oneOf,
+    this.enumeration,
+    this.readOnly = false,
+    this.writeOnly = false,
+    this.format,
+    this.type,
+    this.minimum,
+    this.exclusiveMinimum,
+    this.maximum,
+    this.exclusiveMaximum,
+    this.multipleOf,
+    this.items,
+    this.minItems,
+    this.maxItems,
+    this.properties,
+    this.required,
+    this.minLength,
+    this.maxLength,
+    this.pattern,
+    this.contentEncoding,
+    this.contentMediaType,
+    this.rawJson,
+    Map<String, dynamic>? additionalFields,
+  }) {
+    this.additionalFields.addAll(additionalFields ?? {});
+  }
+
   // TODO: Consider creating separate classes for each data type.
   //       Also see https://github.com/w3c/wot-thing-description/issues/1390
 
   /// Creates a new [DataSchema] from a [json] object.
-  DataSchema.fromJson(Map<String, dynamic> json) {
-    parseDataSchemaJson(this, json);
-    rawJson = json;
+  factory DataSchema.fromJson(
+    Map<String, dynamic> json, [
+    Set<String>? parsedFields,
+  ]) {
+    return DataSchema(
+      atType: json.parseArrayField<String>('@type', parsedFields),
+      title: json.parseField<String>('title', parsedFields),
+      titles: json.parseMapField<String>('titles', parsedFields),
+      description: json.parseField<String>('description', parsedFields),
+      descriptions: json.parseMapField<String>('descriptions', parsedFields),
+      constant: json.parseField<Object>('constant', parsedFields),
+      defaultValue: json.parseField<Object>('default', parsedFields),
+      enumeration: json.parseField<List<Object>>('enum', parsedFields),
+      readOnly: json.parseField<bool>('readOnly', parsedFields),
+      writeOnly: json.parseField<bool>('writeOnly', parsedFields),
+      format: json.parseField<String>('format', parsedFields),
+      unit: json.parseField<String>('unit', parsedFields),
+      type: json.parseField<String>('type', parsedFields),
+      minimum: json.parseField<num>('minimum', parsedFields),
+      exclusiveMinimum: json.parseField<num>('exclusiveMinimum', parsedFields),
+      maximum: json.parseField<num>('minimum', parsedFields),
+      exclusiveMaximum: json.parseField<num>('exclusiveMaximum', parsedFields),
+      multipleOf: json.parseField<num>('multipleOf', parsedFields),
+      items: json.parseDataSchemaArrayField('items'),
+      minItems: json.parseField<int>('minItems', parsedFields),
+      maxItems: json.parseField<int>('maxItems', parsedFields),
+      required: json.parseField<List<String>>('required', parsedFields),
+      minLength: json.parseField<int>('minLength', parsedFields),
+      maxLength: json.parseField<int>('maxLength', parsedFields),
+      pattern: json.parseField<String>('pattern', parsedFields),
+      contentEncoding: json.parseField<String>('contentEncoding', parsedFields),
+      contentMediaType:
+          json.parseField<String>('contentMediaType', parsedFields),
+      oneOf: json.parseDataSchemaArrayField('oneOf', parsedFields),
+      properties: json.parseDataSchemaMapField('properties', parsedFields),
+      rawJson: json,
+    );
   }
 
   /// JSON-LD keyword (@type) to label the object with semantic tags (or types).
-  List<String>? atType;
+  final List<String>? atType;
 
   /// The (default) title of this [DataSchema].
-  String? title;
+  final String? title;
 
   /// A multi-language map of [titles].
-  Map<String, String>? titles;
+  final Map<String, String>? titles;
 
   /// The default [description] of this [DataSchema].
-  String? description;
+  final String? description;
 
   /// A multi-language map of [descriptions].
-  Map<String, String>? descriptions;
+  final Map<String, String>? descriptions;
 
   /// A [constant] value.
-  Object? constant;
+  final Object? constant;
 
   /// A default value if no actual value is set.
-  Object? defaultValue;
+  final Object? defaultValue;
 
   /// The [unit] of the value.
-  String? unit;
+  final String? unit;
 
   /// Allows the specification of multiple [DataSchema]s for validation.
   ///
   /// Data has to be valid against exactly one of these [DataSchema]s.
-  List<DataSchema>? oneOf;
+  final List<DataSchema>? oneOf;
 
   /// Restricted set of values provided as a [List].
-  List<Object>? enumeration;
+  final List<Object>? enumeration;
 
   /// Indicates if a value is read only.
-  bool? readOnly;
+  final bool? readOnly;
 
   /// Indicates if a value is write only.
-  bool? writeOnly;
+  final bool? writeOnly;
 
   /// Allows validation based on a format pattern.
   ///
   /// Examples are "date-time", "email", "uri", etc.
-  String? format;
+  final String? format;
 
   /// JSON-based data type compatible with JSON Schema.
   ///
   /// This value can be one of boolean, integer, number, string, object, array,
   /// or null.
-  String? type;
+  final String? type;
 
   // Number/Integer fields
 
   /// Specifies a minimum numeric value, representing an inclusive lower limit.
   ///
   /// Only applicable for associated number or integer types.
-  num? minimum;
+  final num? minimum;
 
   /// Specifies a minimum numeric value, representing an exclusive lower limit.
   ///
   /// Only applicable for associated number or integer types.
-  num? exclusiveMinimum;
+  final num? exclusiveMinimum;
 
   /// Specifies a maximum numeric value, representing an inclusive upper limit.
   ///
   /// Only applicable for associated number or integer types.
-  num? maximum;
+  final num? maximum;
 
   /// Specifies a maximum numeric value, representing an exclusive upper limit.
   ///
   /// Only applicable for associated number or integer types.
-  num? exclusiveMaximum;
+  final num? exclusiveMaximum;
 
   /// Specifies the multipleOf value number.
   /// The value must strictly greater than 0.
   ///
   /// Only applicable for associated number or integer types.
-  num? multipleOf;
+  final num? multipleOf;
 
   // Array fields
 
   /// Used to define the characteristics of an array.
-  List<DataSchema>? items;
+  final List<DataSchema>? items;
 
   /// Defines the minimum number of items that have to be in an array.
-  int? minItems;
+  final int? minItems;
 
   /// Defines the maximum number of items that have to be in an array.
-  int? maxItems;
+  final int? maxItems;
 
   // Object fields
 
   /// Data schema nested definitions in an `object`.
-  Map<String, DataSchema>? properties;
+  final Map<String, DataSchema>? properties;
 
   /// Defines which members of the `object` type are mandatory, i.e. which
   /// members are mandatory in the payload that is to be sent (e.g. input of
   /// invokeaction, writeproperty) and what members will be definitely delivered
   /// in the payload that is being received (e.g. output of invokeaction,
   /// readproperty).
-  List<String>? required;
+  final List<String>? required;
 
   // String fields
 
   /// Specifies the minimum length of a string.
   ///
   /// Only applicable for associated string types.
-  int? minLength;
+  final int? minLength;
 
   /// Specifies the maximum length of a string.
   ///
   /// Only applicable for associated string types.
-  int? maxLength;
+  final int? maxLength;
 
   /// Provides a regular expression to express constraints of the string value.
   ///
   /// The regular expression must follow the [ECMA-262] dialect.
   ///
   /// [ECMA-262]: https://tc39.es/ecma262/multipage/
-  String? pattern;
+  final String? pattern;
 
   /// Specifies the encoding used to store the contents, as specified in
   /// [RFC 2045] (Section 6.1) and [RFC 4648].
   ///
   /// [RFC 2045]: https://www.rfc-editor.org/rfc/rfc2045
   /// [RFC 4648]: https://www.rfc-editor.org/rfc/rfc4648
-  String? contentEncoding;
+  final String? contentEncoding;
 
   /// Specifies the MIME type of the contents of a string value, as described
   /// in [RFC 2046].
   ///
   /// [RFC 2046]: https://www.rfc-editor.org/rfc/rfc2046
-  String? contentMediaType;
+  final String? contentMediaType;
+
+  /// Additional fields that could not be deserialized as class members.
+  final Map<String, dynamic> additionalFields = {};
 
   /// The original JSON object that was parsed when creating this [DataSchema].
-  Map<String, dynamic>? rawJson;
+  final Map<String, dynamic>? rawJson;
 }

--- a/lib/src/definitions/expected_response.dart
+++ b/lib/src/definitions/expected_response.dart
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:curie/curie.dart';
+
 import 'extensions/json_parser.dart';
 
 /// Communication metadata describing the expected response message for the
@@ -18,23 +20,18 @@ class ExpectedResponse {
         );
 
   /// Creates an [ExpectedResponse] from a [json] object.
-  static ExpectedResponse? fromJson(
-    Map<String, dynamic> json, [
-    Set<String>? parsedFields,
-  ]) {
-    final responseJson = json['response'];
-    parsedFields?.add('response');
+  factory ExpectedResponse.fromJson(
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping,
+  ) {
+    final Set<String> parsedFields = {};
 
-    if (responseJson is! Map<String, dynamic>) {
-      return null;
-    }
+    final contentType =
+        json.parseRequiredField<String>('contentType', parsedFields);
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
 
-    return ExpectedResponse(
-      responseJson.parseRequiredField<String>('contentType'),
-      additionalFields: Map.fromEntries(
-        responseJson.entries.where((element) => element.key != 'contentType'),
-      ),
-    );
+    return ExpectedResponse(contentType, additionalFields: additionalFields);
   }
 
   /// The [contentType] of this [ExpectedResponse] object.

--- a/lib/src/definitions/expected_response.dart
+++ b/lib/src/definitions/expected_response.dart
@@ -38,5 +38,5 @@ class ExpectedResponse {
   String contentType;
 
   /// Any other additional field will be included in this [Map].
-  final Map<String, dynamic> additionalFields;
+  final Map<String, dynamic>? additionalFields;
 }

--- a/lib/src/definitions/extensions/json_parser.dart
+++ b/lib/src/definitions/extensions/json_parser.dart
@@ -3,6 +3,7 @@ import 'package:curie/curie.dart';
 import '../data_schema.dart';
 import '../form.dart';
 import '../interaction_affordances/interaction_affordance.dart';
+import '../link.dart';
 import '../validation/validation_exception.dart';
 
 /// Extension for parsing fields of JSON objects.
@@ -176,6 +177,25 @@ extension ParseField on Map<String, dynamic> {
     return fieldValue
         .whereType<Map<String, dynamic>>()
         .map((e) => Form.fromJson(e, interactionAffordance))
+        .toList();
+  }
+
+  /// Parses [Link]s contained in this JSON object.
+  ///
+  /// Adds the key `links` to the set of [parsedFields], if defined.
+  List<Link>? parseLinks(
+    PrefixMapping prefixMapping, [
+    Set<String>? parsedFields,
+  ]) {
+    final fieldValue = parseField('links', parsedFields);
+
+    if (fieldValue is! List) {
+      return null;
+    }
+
+    return fieldValue
+        .whereType<Map<String, dynamic>>()
+        .map(Link.fromJson)
         .toList();
   }
 }

--- a/lib/src/definitions/extensions/json_parser.dart
+++ b/lib/src/definitions/extensions/json_parser.dart
@@ -2,8 +2,13 @@ import 'package:curie/curie.dart';
 
 import '../data_schema.dart';
 import '../form.dart';
+import '../interaction_affordances/action.dart';
+import '../interaction_affordances/event.dart';
 import '../interaction_affordances/interaction_affordance.dart';
+import '../interaction_affordances/property.dart';
 import '../link.dart';
+import '../security/security_scheme.dart';
+import '../thing_description.dart';
 import '../validation/validation_exception.dart';
 
 /// Extension for parsing fields of JSON objects.
@@ -197,5 +202,116 @@ extension ParseField on Map<String, dynamic> {
         .whereType<Map<String, dynamic>>()
         .map(Link.fromJson)
         .toList();
+  }
+
+  /// Parses [SecurityScheme]s contained in this JSON object.
+  ///
+  /// Adds the key `securityDefinitions` to the set of [parsedFields], if
+  /// defined.
+  Map<String, SecurityScheme>? parseSecurityDefinitions(
+    PrefixMapping prefixMapping, [
+    Set<String>? parsedFields,
+  ]) {
+    final fieldValue =
+        parseMapField<dynamic>('securityDefinitions', parsedFields);
+
+    if (fieldValue == null) {
+      return null;
+    }
+
+    final Map<String, SecurityScheme> result = {};
+
+    for (final securityDefinition in fieldValue.entries) {
+      final dynamic value = securityDefinition.value;
+      if (value is Map<String, dynamic>) {
+        final securityScheme = SecurityScheme.fromJson(value);
+        if (securityScheme != null) {
+          result[securityDefinition.key] = securityScheme;
+        }
+      }
+    }
+
+    return result;
+  }
+
+  /// Parses [Property]s contained in this JSON object.
+  ///
+  /// Adds the key `properties` to the set of [parsedFields], if defined.
+  Map<String, Property>? parseProperties(
+    ThingDescription thingDescription,
+    PrefixMapping prefixMapping, [
+    Set<String>? parsedFields,
+  ]) {
+    final fieldValue = parseMapField<dynamic>('properties', parsedFields);
+
+    if (fieldValue == null) {
+      return null;
+    }
+
+    final Map<String, Property> result = {};
+
+    for (final property in fieldValue.entries) {
+      final dynamic value = property.value;
+      if (value is Map<String, dynamic>) {
+        result[property.key] =
+            Property.fromJson(value, thingDescription, prefixMapping);
+      }
+    }
+
+    return result;
+  }
+
+  /// Parses [Action]s contained in this JSON object.
+  ///
+  /// Adds the key `actions` to the set of [parsedFields], if defined.
+  Map<String, Action>? parseActions(
+    ThingDescription thingDescription,
+    PrefixMapping prefixMapping, [
+    Set<String>? parsedFields,
+  ]) {
+    final fieldValue = parseMapField<dynamic>('actions', parsedFields);
+
+    if (fieldValue == null) {
+      return null;
+    }
+
+    final Map<String, Action> result = {};
+
+    for (final property in fieldValue.entries) {
+      final dynamic value = property.value;
+      if (value is Map<String, dynamic>) {
+        result[property.key] =
+            Action.fromJson(value, thingDescription, prefixMapping);
+      }
+    }
+
+    return result;
+  }
+
+  /// Parses [Event]s contained in this JSON object.
+  ///
+  /// Adds the key `events` to the set of [parsedFields], if defined.
+  Map<String, Event>? parseEvents(
+    ThingDescription thingDescription,
+    PrefixMapping prefixMapping, [
+    Set<String>? parsedFields,
+  ]) {
+    final fieldValue = parseMapField<dynamic>('events', parsedFields);
+
+    if (fieldValue == null) {
+      return null;
+    }
+
+    final Map<String, Event> result = {};
+
+    for (final property in fieldValue.entries) {
+      final dynamic value = property.value;
+      if (value is Map<String, dynamic>) {
+        result[property.key] =
+            Event.fromJson(value, thingDescription, prefixMapping);
+      }
+    }
+
+    return result;
   }
 }

--- a/lib/src/definitions/extensions/json_parser.dart
+++ b/lib/src/definitions/extensions/json_parser.dart
@@ -2,6 +2,11 @@ import '../validation/validation_exception.dart';
 
 /// Extension for parsing fields of JSON objects.
 extension ParseField on Map<String, dynamic> {
+  dynamic _processFieldName(String name, Set<String>? parsedFields) {
+    parsedFields?.add(name);
+    return this[name];
+  }
+
   /// Parses a single field with a given [name].
   ///
   /// Ensures that the field value is of type [T] and returns `null` if the
@@ -10,10 +15,10 @@ extension ParseField on Map<String, dynamic> {
   /// If a [Set] of [parsedFields] is passed to this function, the field [name]
   /// will added. This can be used for filtering when parsing additional fields.
   T? parseField<T>(String name, [Set<String>? parsedFields]) {
-    final value = this[name];
-    parsedFields?.add(name);
-    if (value is T) {
-      return value;
+    final fieldValue = _processFieldName(name, parsedFields);
+
+    if (fieldValue is T) {
+      return fieldValue;
     }
 
     return null;
@@ -26,16 +31,16 @@ extension ParseField on Map<String, dynamic> {
   /// Like [parseField], it adds the field [name] to the set of [parsedFields],
   /// if present.
   T parseRequiredField<T>(String name, [Set<String>? parsedFields]) {
-    final value = parseField(name, parsedFields);
+    final fieldValue = parseField(name, parsedFields);
 
-    if (value is! T) {
+    if (fieldValue is! T) {
       throw ValidationException(
         'Value for field $name has wrong data type or is missing. '
-        'Expected ${T.runtimeType}, got ${value.runtimeType}.',
+        'Expected ${T.runtimeType}, got ${fieldValue.runtimeType}.',
       );
     }
 
-    return value;
+    return fieldValue;
   }
 
   /// Parses a map field with a given [name].
@@ -46,13 +51,12 @@ extension ParseField on Map<String, dynamic> {
   /// If a [Set] of [parsedFields] is passed to this function, the field [name]
   /// will added. This can be used for filtering when parsing additional fields.
   Map<String, T>? parseMapField<T>(String name, [Set<String>? parsedFields]) {
-    final dynamic mapField = this[name];
-    parsedFields?.add(name);
+    final fieldValue = _processFieldName(name, parsedFields);
 
-    if (mapField is Map<String, dynamic>) {
+    if (fieldValue is Map<String, dynamic>) {
       final Map<String, T> result = {};
 
-      for (final entry in mapField.entries) {
+      for (final entry in fieldValue.entries) {
         final value = entry.value;
         if (value is T) {
           result[entry.key] = value;
@@ -73,13 +77,12 @@ extension ParseField on Map<String, dynamic> {
   /// If a [Set] of [parsedFields] is passed to this function, the field [name]
   /// will added. This can be used for filtering when parsing additional fields.
   List<T>? parseArrayField<T>(String name, [Set<String>? parsedFields]) {
-    final value = this[name];
-    parsedFields?.add(name);
+    final fieldValue = parseField(name, parsedFields);
 
-    if (value is T) {
-      return [value];
-    } else if (value is List<dynamic>) {
-      return value.whereType<T>().toList(growable: false);
+    if (fieldValue is T) {
+      return [fieldValue];
+    } else if (fieldValue is List<dynamic>) {
+      return fieldValue.whereType<T>().toList(growable: false);
     }
 
     return null;

--- a/lib/src/definitions/extensions/json_parser.dart
+++ b/lib/src/definitions/extensions/json_parser.dart
@@ -35,6 +35,23 @@ extension ParseField on Map<String, dynamic> {
     return null;
   }
 
+  /// Parses a single field with a given [name] as a [Uri].
+  ///
+  /// Ensures that the field value is a valid [Uri] and returns `null` if the
+  /// value cannot be parsed as such.
+  ///
+  /// If a [Set] of [parsedFields] is passed to this function, the field [name]
+  /// will added. This can be used for filtering when parsing additional fields.
+  Uri? parseUriField(String name, [Set<String>? parsedFields]) {
+    final fieldValue = parseField<String>(name, parsedFields);
+
+    if (fieldValue == null) {
+      return null;
+    }
+
+    return Uri.tryParse(fieldValue);
+  }
+
   /// Parses a single field with a given [name] and throws a
   /// [ValidationException] if the field is not present or does not have the
   /// type [T].
@@ -52,6 +69,17 @@ extension ParseField on Map<String, dynamic> {
     }
 
     return fieldValue;
+  }
+
+  /// Parses a single field with a given [name] as a [Uri] and throws a
+  /// [ValidationException] if the field is not present or cannot be parsed.
+  ///
+  /// If a [Set] of [parsedFields] is passed to this function, the field [name]
+  /// will added. This can be used for filtering when parsing additional fields.
+  Uri parseRequiredUriField(String name, [Set<String>? parsedFields]) {
+    final fieldValue = parseRequiredField<String>(name, parsedFields);
+
+    return Uri.parse(fieldValue);
   }
 
   /// Parses a map field with a given [name].

--- a/lib/src/definitions/extensions/json_parser.dart
+++ b/lib/src/definitions/extensions/json_parser.dart
@@ -165,9 +165,9 @@ extension ParseField on Map<String, dynamic> {
   /// will added. This can be used for filtering when parsing additional fields.
   DataSchema? parseDataSchemaField(
     String name,
-    PrefixMapping prefixMapping, [
+    PrefixMapping prefixMapping,
     Set<String>? parsedFields,
-  ]) {
+  ) {
     final fieldValue = parseField(name, parsedFields);
 
     if (fieldValue is Map<String, dynamic>) {
@@ -186,9 +186,9 @@ extension ParseField on Map<String, dynamic> {
   /// will added. This can be used for filtering when parsing additional fields.
   List<DataSchema>? parseDataSchemaArrayField(
     String name,
-    PrefixMapping prefixMapping, [
+    PrefixMapping prefixMapping,
     Set<String>? parsedFields,
-  ]) {
+  ) {
     final fieldValue = parseField(name, parsedFields);
 
     if (fieldValue is List<Map<String, dynamic>>) {
@@ -209,9 +209,9 @@ extension ParseField on Map<String, dynamic> {
   /// will added. This can be used for filtering when parsing additional fields.
   Map<String, DataSchema>? parseDataSchemaMapField(
     String name,
-    PrefixMapping prefixMapping, [
+    PrefixMapping prefixMapping,
     Set<String>? parsedFields,
-  ]) {
+  ) {
     final fieldValue = parseField(name, parsedFields);
 
     if (fieldValue is Map<String, Map<String, dynamic>>) {
@@ -236,8 +236,8 @@ extension ParseField on Map<String, dynamic> {
   /// Adds the key `forms` to the set of [parsedFields], if defined.
   List<Form>? parseForms(
     ThingDescription thingDescription,
-    PrefixMapping prefixMapping, [
-    Set<String>? parsedFields,
+    PrefixMapping prefixMapping,
+    Set<String>? parsedFields, [
     InteractionAffordance? interactionAffordance,
   ]) {
     final fieldValue = parseField('forms', parsedFields);
@@ -268,9 +268,9 @@ extension ParseField on Map<String, dynamic> {
   /// Adds the key `forms` to the set of [parsedFields], if defined.
   List<Form> parseAffordanceForms(
     InteractionAffordance interactionAffordance,
-    PrefixMapping prefixMapping, [
+    PrefixMapping prefixMapping,
     Set<String>? parsedFields,
-  ]) {
+  ) {
     final forms = parseForms(
       interactionAffordance.thingDescription,
       prefixMapping,
@@ -291,9 +291,9 @@ extension ParseField on Map<String, dynamic> {
   ///
   /// Adds the key `links` to the set of [parsedFields], if defined.
   List<Link>? parseLinks(
-    PrefixMapping prefixMapping, [
+    PrefixMapping prefixMapping,
     Set<String>? parsedFields,
-  ]) {
+  ) {
     final fieldValue = parseField('links', parsedFields);
 
     if (fieldValue is! List) {
@@ -311,9 +311,9 @@ extension ParseField on Map<String, dynamic> {
   /// Adds the key `securityDefinitions` to the set of [parsedFields], if
   /// defined.
   Map<String, SecurityScheme>? parseSecurityDefinitions(
-    PrefixMapping prefixMapping, [
+    PrefixMapping prefixMapping,
     Set<String>? parsedFields,
-  ]) {
+  ) {
     final fieldValue =
         parseMapField<dynamic>('securityDefinitions', parsedFields);
 
@@ -341,9 +341,9 @@ extension ParseField on Map<String, dynamic> {
   /// Adds the key `properties` to the set of [parsedFields], if defined.
   Map<String, Property>? parseProperties(
     ThingDescription thingDescription,
-    PrefixMapping prefixMapping, [
+    PrefixMapping prefixMapping,
     Set<String>? parsedFields,
-  ]) {
+  ) {
     final fieldValue = parseMapField<dynamic>('properties', parsedFields);
 
     if (fieldValue == null) {
@@ -368,9 +368,9 @@ extension ParseField on Map<String, dynamic> {
   /// Adds the key `actions` to the set of [parsedFields], if defined.
   Map<String, Action>? parseActions(
     ThingDescription thingDescription,
-    PrefixMapping prefixMapping, [
+    PrefixMapping prefixMapping,
     Set<String>? parsedFields,
-  ]) {
+  ) {
     final fieldValue = parseMapField<dynamic>('actions', parsedFields);
 
     if (fieldValue == null) {
@@ -395,9 +395,9 @@ extension ParseField on Map<String, dynamic> {
   /// Adds the key `events` to the set of [parsedFields], if defined.
   Map<String, Event>? parseEvents(
     ThingDescription thingDescription,
-    PrefixMapping prefixMapping, [
+    PrefixMapping prefixMapping,
     Set<String>? parsedFields,
-  ]) {
+  ) {
     final fieldValue = parseMapField<dynamic>('events', parsedFields);
 
     if (fieldValue == null) {
@@ -421,9 +421,9 @@ extension ParseField on Map<String, dynamic> {
   ///
   /// Adds the key `events` to the set of [parsedFields], if defined.
   ExpectedResponse? parseExpectedResponse(
-    PrefixMapping prefixMapping, [
+    PrefixMapping prefixMapping,
     Set<String>? parsedFields,
-  ]) {
+  ) {
     final fieldValue = parseMapField<dynamic>('response', parsedFields);
 
     if (fieldValue == null) {
@@ -439,9 +439,9 @@ extension ParseField on Map<String, dynamic> {
   /// defined.
   List<AdditionalExpectedResponse>? parseAdditionalExpectedResponse(
     PrefixMapping prefixMapping,
-    String formContentType, [
+    String formContentType,
     Set<String>? parsedFields,
-  ]) {
+  ) {
     final fieldValue = parseArrayField<Map<String, dynamic>>(
       'additionalResponses',
       parsedFields,
@@ -466,9 +466,9 @@ extension ParseField on Map<String, dynamic> {
   ///
   /// Adds the key `version` to the set of [parsedFields], if defined.
   VersionInfo? parseVersionInfo(
-    PrefixMapping prefixMapping, [
+    PrefixMapping prefixMapping,
     Set<String>? parsedFields,
-  ]) {
+  ) {
     final fieldValue = parseMapField<dynamic>('version', parsedFields);
 
     if (fieldValue == null) {
@@ -486,9 +486,9 @@ extension ParseField on Map<String, dynamic> {
   /// If a [Set] of [parsedFields] is passed to this function, the field [name]
   /// will added. This can be used for filtering when parsing additional fields.
   DateTime? parseDateTime(
-    String name, [
+    String name,
     Set<String>? parsedFields,
-  ]) {
+  ) {
     final fieldValue = parseField<String>(name, parsedFields);
 
     if (fieldValue == null) {

--- a/lib/src/definitions/form.dart
+++ b/lib/src/definitions/form.dart
@@ -51,8 +51,7 @@ class Form {
     InteractionAffordance interactionAffordance,
   ) {
     final Set<String> parsedFields = {};
-    final href =
-        Uri.parse(json.parseRequiredField<String>('href', parsedFields));
+    final href = json.parseRequiredUriField('href', parsedFields);
 
     final subprotocol = json.parseField<String>('subprotocol', parsedFields);
 

--- a/lib/src/definitions/form.dart
+++ b/lib/src/definitions/form.dart
@@ -215,10 +215,10 @@ class Form {
       return [OperationType.invokeaction];
     } else if (interactionAffordance is Property) {
       final List<OperationType> op = [];
-      if (!(interactionAffordance.readOnly ?? false)) {
+      if (!interactionAffordance.readOnly) {
         op.add(OperationType.readproperty);
       }
-      if (!(interactionAffordance.writeOnly ?? false)) {
+      if (!interactionAffordance.writeOnly) {
         op.add(OperationType.writeproperty);
       }
       return op;

--- a/lib/src/definitions/interaction_affordances/action.dart
+++ b/lib/src/definitions/interaction_affordances/action.dart
@@ -69,9 +69,8 @@ class Action extends InteractionAffordance {
     );
 
     action.forms.addAll(json.parseForms(action, prefixMapping, parsedFields));
-    action.additionalFields.addEntries(
-      json.entries.where((entry) => !parsedFields.contains(entry.key)),
-    );
+    action.additionalFields
+        .addAll(json.parseAdditionalFields(prefixMapping, parsedFields));
 
     return action;
   }

--- a/lib/src/definitions/interaction_affordances/action.dart
+++ b/lib/src/definitions/interaction_affordances/action.dart
@@ -51,8 +51,10 @@ class Action extends InteractionAffordance {
     final idempotent =
         json.parseField<bool>('idempotent', parsedFields) ?? false;
     final synchronous = json.parseField<bool>('synchronous', parsedFields);
-    final input = json.parseDataSchemaField('input', parsedFields);
-    final output = json.parseDataSchemaField('output', parsedFields);
+    final input =
+        json.parseDataSchemaField('input', prefixMapping, parsedFields);
+    final output =
+        json.parseDataSchemaField('output', prefixMapping, parsedFields);
 
     final action = Action(
       thingDescription,
@@ -68,7 +70,8 @@ class Action extends InteractionAffordance {
       output: output,
     );
 
-    action.forms.addAll(json.parseForms(action, prefixMapping, parsedFields));
+    action.forms
+        .addAll(json.parseAffordanceForms(action, prefixMapping, parsedFields));
     action.additionalFields
         .addAll(json.parseAdditionalFields(prefixMapping, parsedFields));
 

--- a/lib/src/definitions/interaction_affordances/action.dart
+++ b/lib/src/definitions/interaction_affordances/action.dart
@@ -5,51 +5,95 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import 'package:curie/curie.dart';
+import 'package:meta/meta.dart';
 
 import '../data_schema.dart';
+import '../extensions/json_parser.dart';
 import '../thing_description.dart';
 import 'interaction_affordance.dart';
 
 /// Class representing an [Action] Affordance in a Thing Description.
+@immutable
 class Action extends InteractionAffordance {
   /// Creates a new [Action] from a [List] of [forms].
-  Action(super.forms, super.thingDescription);
+  Action(
+    super.thingDescription, {
+    super.title,
+    super.titles,
+    super.description,
+    super.descriptions,
+    super.uriVariables,
+    super.forms,
+    this.safe = false,
+    this.idempotent = false,
+    this.synchronous,
+    this.input,
+    this.output,
+  });
 
   /// Creates a new [Action] from a [json] object.
-  Action.fromJson(
+  factory Action.fromJson(
     Map<String, dynamic> json,
     ThingDescription thingDescription,
     PrefixMapping prefixMapping,
-  ) : super([], thingDescription) {
-    final List<String> parsedFields = [];
-    _parseActionFields(json, parsedFields);
-    parseAffordanceFields(json, prefixMapping);
+  ) {
+    final Set<String> parsedFields = {};
+
+    final title = json.parseField<String>('title', parsedFields);
+    final titles = json.parseMapField<String>('titles', parsedFields);
+    final description = json.parseField<String>('description', parsedFields);
+    final descriptions =
+        json.parseMapField<String>('descriptions', parsedFields);
+    final uriVariables =
+        json.parseMapField<dynamic>('uriVariables', parsedFields);
+
+    final safe = json.parseField<bool>('safe', parsedFields) ?? false;
+    final idempotent =
+        json.parseField<bool>('idempotent', parsedFields) ?? false;
+    final synchronous = json.parseField<bool>('synchronous', parsedFields);
+    final input = json.parseDataSchemaField('input', parsedFields);
+    final output = json.parseDataSchemaField('output', parsedFields);
+
+    final action = Action(
+      thingDescription,
+      title: title,
+      titles: titles,
+      description: description,
+      descriptions: descriptions,
+      uriVariables: uriVariables,
+      safe: safe,
+      idempotent: idempotent,
+      synchronous: synchronous,
+      input: input,
+      output: output,
+    );
+
+    action.forms.addAll(json.parseForms(action, prefixMapping, parsedFields));
+    action.additionalFields.addEntries(
+      json.entries.where((entry) => !parsedFields.contains(entry.key)),
+    );
+
+    return action;
   }
 
   /// The schema of the [input] data this [Action] accepts.
-  DataSchema? input;
+  final DataSchema? input;
 
   /// The schema of the [output] data this [Action] produces.
-  DataSchema? output;
-
-  bool _idempotent = false;
+  final DataSchema? output;
 
   /// Indicates whether the Action is idempotent (=true) or not.
   ///
   /// Informs whether the Action can be called repeatedly with the same result,
   /// if present, based on the same input.
-  bool get idempotent => _idempotent;
-
-  bool _safe = false;
+  final bool idempotent;
 
   /// Signals if the Action is safe (=true) or not.
   ///
   /// Used to signal if there is no internal state (cf. resource state) is
   /// changed when invoking an Action. In that case responses can be cached as
   /// example.
-  bool get safe => _safe;
-
-  bool? _synchronous;
+  final bool safe;
 
   /// Indicates whether the action is synchronous (=true) or not.
   ///
@@ -57,47 +101,5 @@ class Action extends InteractionAffordance {
   /// information about the result of the action and no further querying about
   /// the status of the action is needed. Lack of this keyword means that no
   /// claim on the synchronicity of the action can be made.
-  bool? get synchronous => _synchronous;
-
-  T? _parseJsonValue<T>(
-    Map<String, dynamic> json,
-    String key,
-    List<String> parsedFields,
-  ) {
-    parsedFields.add(key);
-    final dynamic value = json[key];
-    if (value is T) {
-      return value;
-    }
-
-    return null;
-  }
-
-  void _parseIdempotent(
-    Map<String, dynamic> json,
-    List<String> parsedFields,
-  ) {
-    _idempotent =
-        _parseJsonValue<bool>(json, 'idempotent', parsedFields) ?? _idempotent;
-  }
-
-  void _parseSafe(Map<String, dynamic> json, List<String> parsedFields) {
-    _safe = _parseJsonValue<bool>(json, 'safe', parsedFields) ?? _safe;
-  }
-
-  void _parseSynchronous(
-    Map<String, dynamic> json,
-    List<String> parsedFields,
-  ) {
-    _synchronous = _parseJsonValue<bool>(json, 'synchronous', parsedFields);
-  }
-
-  void _parseActionFields(
-    Map<String, dynamic> json,
-    List<String> parsedFields,
-  ) {
-    _parseIdempotent(json, parsedFields);
-    _parseSafe(json, parsedFields);
-    _parseSynchronous(json, parsedFields);
-  }
+  final bool? synchronous;
 }

--- a/lib/src/definitions/interaction_affordances/event.dart
+++ b/lib/src/definitions/interaction_affordances/event.dart
@@ -64,8 +64,8 @@ class Event extends InteractionAffordance {
     );
 
     event.forms.addAll(json.parseForms(event, prefixMapping));
-    event.additionalFields.addEntries(
-      json.entries.where((entry) => !parsedFields.contains(entry.key)),
+    event.additionalFields.addAll(
+      json.parseAdditionalFields(prefixMapping, parsedFields),
     );
 
     return event;

--- a/lib/src/definitions/interaction_affordances/event.dart
+++ b/lib/src/definitions/interaction_affordances/event.dart
@@ -63,7 +63,8 @@ class Event extends InteractionAffordance {
       cancellation: cancellation,
     );
 
-    event.forms.addAll(json.parseAffordanceForms(event, prefixMapping));
+    event.forms
+        .addAll(json.parseAffordanceForms(event, prefixMapping, parsedFields));
     event.additionalFields.addAll(
       json.parseAdditionalFields(prefixMapping, parsedFields),
     );

--- a/lib/src/definitions/interaction_affordances/event.dart
+++ b/lib/src/definitions/interaction_affordances/event.dart
@@ -5,39 +5,79 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import 'package:curie/curie.dart';
+import 'package:meta/meta.dart';
 
 import '../data_schema.dart';
+import '../extensions/json_parser.dart';
 import '../thing_description.dart';
 import 'interaction_affordance.dart';
 
 /// Class representing an [Event] Affordance in a Thing Description.
+@immutable
 class Event extends InteractionAffordance {
   /// Creates a new [Event] from a [List] of [forms].
-  Event(super.forms, super.thingDescription);
+  Event(
+    super.thingDescription, {
+    super.title,
+    super.titles,
+    super.description,
+    super.descriptions,
+    super.uriVariables,
+    super.forms,
+    this.subscription,
+    this.data,
+    this.cancellation,
+  });
 
   /// Creates a new [Event] from a [json] object.
-  Event.fromJson(
+  factory Event.fromJson(
     Map<String, dynamic> json,
     ThingDescription thingDescription,
     PrefixMapping prefixMapping,
-  ) : super([], thingDescription) {
-    parseAffordanceFields(json, prefixMapping);
-    _parseEventFields(json);
+  ) {
+    final Set<String> parsedFields = {};
+
+    final title = json.parseField<String>('title', parsedFields);
+    final titles = json.parseMapField<String>('titles', parsedFields);
+    final description = json.parseField<String>('description', parsedFields);
+    final descriptions =
+        json.parseMapField<String>('descriptions', parsedFields);
+    final uriVariables =
+        json.parseMapField<dynamic>('uriVariables', parsedFields);
+
+    final subscription =
+        json.parseDataSchemaField('subscription', parsedFields);
+    final data = json.parseDataSchemaField('data', parsedFields);
+    final cancellation =
+        json.parseDataSchemaField('cancellation', parsedFields);
+
+    final event = Event(
+      thingDescription,
+      title: title,
+      titles: titles,
+      description: description,
+      descriptions: descriptions,
+      uriVariables: uriVariables,
+      subscription: subscription,
+      data: data,
+      cancellation: cancellation,
+    );
+
+    event.forms.addAll(json.parseForms(event, prefixMapping));
+    event.additionalFields.addEntries(
+      json.entries.where((entry) => !parsedFields.contains(entry.key)),
+    );
+
+    return event;
   }
 
   /// Defines data that needs to be passed upon [subscription].
-  DataSchema? subscription;
+  final DataSchema? subscription;
 
   /// Defines the [DataSchema] of the Event instance messages pushed by the
   /// Thing.
-  DataSchema? data;
+  final DataSchema? data;
 
   /// Defines any data that needs to be passed to cancel a subscription.
-  DataSchema? cancellation;
-
-  void _parseEventFields(Map<String, dynamic> json) {
-    subscription = DataSchema.fromJson(json);
-    data = DataSchema.fromJson(json);
-    cancellation = DataSchema.fromJson(json);
-  }
+  final DataSchema? cancellation;
 }

--- a/lib/src/definitions/interaction_affordances/event.dart
+++ b/lib/src/definitions/interaction_affordances/event.dart
@@ -46,10 +46,10 @@ class Event extends InteractionAffordance {
         json.parseMapField<dynamic>('uriVariables', parsedFields);
 
     final subscription =
-        json.parseDataSchemaField('subscription', parsedFields);
-    final data = json.parseDataSchemaField('data', parsedFields);
+        json.parseDataSchemaField('subscription', prefixMapping, parsedFields);
+    final data = json.parseDataSchemaField('data', prefixMapping, parsedFields);
     final cancellation =
-        json.parseDataSchemaField('cancellation', parsedFields);
+        json.parseDataSchemaField('cancellation', prefixMapping, parsedFields);
 
     final event = Event(
       thingDescription,
@@ -63,7 +63,7 @@ class Event extends InteractionAffordance {
       cancellation: cancellation,
     );
 
-    event.forms.addAll(json.parseForms(event, prefixMapping));
+    event.forms.addAll(json.parseAffordanceForms(event, prefixMapping));
     event.additionalFields.addAll(
       json.parseAdditionalFields(prefixMapping, parsedFields),
     );

--- a/lib/src/definitions/interaction_affordances/interaction_affordance.dart
+++ b/lib/src/definitions/interaction_affordances/interaction_affordance.dart
@@ -4,63 +4,53 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
+import 'package:meta/meta.dart';
 
-import '../extensions/json_parser.dart';
 import '../form.dart';
 import '../thing_description.dart';
 
 /// Base class for Interaction Affordances (Properties, Actions, and Events).
+@immutable
 abstract class InteractionAffordance {
   // TODO(JKRhb): Make fields final
 
   /// Creates a new [InteractionAffordance]. Accepts a [List] of [forms].
-  InteractionAffordance(this.forms, this.thingDescription);
+  InteractionAffordance(
+    this.thingDescription, {
+    this.title,
+    this.titles,
+    this.description,
+    this.descriptions,
+    this.uriVariables,
+    List<Form>? forms,
+  }) {
+    this.forms.addAll(forms ?? []);
+  }
 
   /// Reference to the [ThingDescription] containing this
   /// [InteractionAffordance].
   final ThingDescription thingDescription;
 
   /// The default [title] of this [InteractionAffordance].
-  String? title;
+  final String? title;
 
   /// Multilanguage [titles] of this [InteractionAffordance].
-  Map<String, String>? titles;
+  final Map<String, String>? titles;
 
   /// The default [description] of this [InteractionAffordance].
-  String? description;
+  final String? description;
 
   /// Multilanguage [descriptions] of this [InteractionAffordance].
-  Map<String, String>? descriptions;
+  final Map<String, String>? descriptions;
 
   /// The basic [forms] which can be used for interacting with this resource.
-  final List<Form> forms;
+  final List<Form> forms = [];
 
   /// URI template variables as defined in [RFC 6570].
   ///
   /// [RFC 6570]: http://tools.ietf.org/html/rfc6570
-  Map<String, Object?>? uriVariables;
+  final Map<String, Object?>? uriVariables;
 
-  /// Parses [forms] represented by a [json] object.
-  void _parseForms(Map<String, dynamic> json, PrefixMapping prefixMapping) {
-    for (final formJson in json['forms']) {
-      if (formJson is Map<String, dynamic>) {
-        forms.add(Form.fromJson(formJson, this));
-      }
-    }
-  }
-
-  /// Parses the [InteractionAffordance] contained in a [json] object.
-  void parseAffordanceFields(
-    Map<String, dynamic> json,
-    PrefixMapping prefixMapping,
-  ) {
-    _parseForms(json, prefixMapping);
-
-    title = json.parseField('title');
-    titles = json.parseMapField<String>('titles');
-    description = json.parseField('description');
-    descriptions = json.parseMapField<String>('descriptions');
-    uriVariables = json.parseMapField<dynamic>('uriVariables');
-  }
+  /// Additional fields that could not be deserialized as class members.
+  final Map<String, dynamic> additionalFields = {};
 }

--- a/lib/src/definitions/interaction_affordances/property.dart
+++ b/lib/src/definitions/interaction_affordances/property.dart
@@ -44,8 +44,8 @@ class Property extends InteractionAffordance implements DataSchema {
     );
 
     property.forms.addAll(json.parseForms(property, prefixMapping));
-    property.additionalFields.addEntries(
-      json.entries.where((element) => !parsedFields.contains(element.key)),
+    property.additionalFields.addAll(
+      json.parseAdditionalFields(prefixMapping, parsedFields),
     );
 
     return property;

--- a/lib/src/definitions/interaction_affordances/property.dart
+++ b/lib/src/definitions/interaction_affordances/property.dart
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import 'package:curie/curie.dart';
+import 'package:meta/meta.dart';
 
 import '../data_schema.dart';
 import '../extensions/json_parser.dart';
@@ -12,96 +13,133 @@ import '../thing_description.dart';
 import 'interaction_affordance.dart';
 
 /// Class representing a [Property] Affordance in a Thing Description.
+@immutable
 class Property extends InteractionAffordance implements DataSchema {
   /// Default constructor that creates a [Property] from a [List] of [forms].
-  Property(super.forms, super.thingDescription, {this.observable = false});
+  Property(
+    super.thingDescription, {
+    super.forms,
+    super.uriVariables,
+    this.dataSchema,
+    this.observable = false,
+  });
 
   /// Creates a new [Property] from a [json] object.
-  Property.fromJson(
+  factory Property.fromJson(
     Map<String, dynamic> json,
     ThingDescription thingDescription,
     PrefixMapping prefixMapping,
-  )   : observable = json.parseField<bool>('observable') ?? false,
-        super([], thingDescription) {
-    parseAffordanceFields(json, prefixMapping);
-    parseDataSchemaJson(this, json);
-    rawJson = json;
+  ) {
+    final Set<String> parsedFields = {};
+    final observable = json.parseField<bool>('observable') ?? false;
+    final dataSchema =
+        DataSchema.fromJson(json, {'observable', 'uriVariables'});
+    final uriVariables = json.parseMapField<dynamic>('uriVariables');
+
+    final property = Property(
+      thingDescription,
+      observable: observable,
+      dataSchema: dataSchema,
+      uriVariables: uriVariables,
+    );
+
+    property.forms.addAll(json.parseForms(property, prefixMapping));
+    property.additionalFields.addEntries(
+      json.entries.where((element) => !parsedFields.contains(element.key)),
+    );
+
+    return property;
   }
 
-  @override
-  List<String>? atType;
+  /// The internal [DataSchema] this property is based on.
+  final DataSchema? dataSchema;
 
   @override
-  Object? constant;
+  String? get title => dataSchema?.title;
 
   @override
-  Object? defaultValue;
+  Map<String, String>? get titles => dataSchema?.titles;
 
   @override
-  List<Object>? enumeration;
+  String? get description => dataSchema?.description;
 
   @override
-  String? format;
+  Map<String, String>? get descriptions => dataSchema?.descriptions;
 
   @override
-  List<DataSchema>? oneOf;
+  List<String>? get atType => dataSchema?.atType;
 
   @override
-  bool? readOnly = false;
+  Object? get constant => dataSchema?.constant;
 
   @override
-  String? type;
+  Object? get defaultValue => dataSchema?.defaultValue;
 
   @override
-  String? unit;
+  List<Object>? get enumeration => dataSchema?.enumeration;
 
   @override
-  bool? writeOnly = false;
+  String? get format => dataSchema?.format;
 
   @override
-  String? contentEncoding;
+  List<DataSchema>? get oneOf => dataSchema?.oneOf;
 
   @override
-  String? contentMediaType;
+  bool get readOnly => dataSchema?.readOnly ?? false;
 
   @override
-  num? exclusiveMaximum;
+  String? get type => dataSchema?.type;
 
   @override
-  num? exclusiveMinimum;
+  String? get unit => dataSchema?.unit;
 
   @override
-  List<DataSchema>? items;
+  bool get writeOnly => dataSchema?.writeOnly ?? false;
 
   @override
-  int? maxItems;
+  String? get contentEncoding => dataSchema?.contentEncoding;
 
   @override
-  int? maxLength;
+  String? get contentMediaType => dataSchema?.contentMediaType;
 
   @override
-  num? maximum;
+  num? get exclusiveMaximum => dataSchema?.exclusiveMaximum;
 
   @override
-  int? minItems;
+  num? get exclusiveMinimum => dataSchema?.exclusiveMinimum;
 
   @override
-  int? minLength;
+  List<DataSchema>? get items => dataSchema?.items;
 
   @override
-  num? minimum;
+  int? get maxItems => dataSchema?.maxItems;
 
   @override
-  num? multipleOf;
+  int? get maxLength => dataSchema?.maxLength;
 
   @override
-  String? pattern;
+  num? get maximum => dataSchema?.maximum;
 
   @override
-  Map<String, DataSchema>? properties;
+  int? get minItems => dataSchema?.minItems;
 
   @override
-  List<String>? required;
+  int? get minLength => dataSchema?.minItems;
+
+  @override
+  num? get minimum => dataSchema?.minimum;
+
+  @override
+  num? get multipleOf => dataSchema?.multipleOf;
+
+  @override
+  String? get pattern => dataSchema?.pattern;
+
+  @override
+  Map<String, DataSchema>? get properties => dataSchema?.properties;
+
+  @override
+  List<String>? get required => dataSchema?.required;
 
   /// A hint that indicates whether Servients hosting the Thing and
   /// Intermediaries should provide a Protocol Binding that supports the
@@ -109,5 +147,9 @@ class Property extends InteractionAffordance implements DataSchema {
   final bool observable;
 
   @override
-  Map<String, dynamic>? rawJson;
+  Map<String, dynamic>? get rawJson => dataSchema?.rawJson;
+
+  @override
+  Map<String, dynamic> get additionalFields =>
+      dataSchema?.additionalFields ?? {};
 }

--- a/lib/src/definitions/interaction_affordances/property.dart
+++ b/lib/src/definitions/interaction_affordances/property.dart
@@ -31,10 +31,11 @@ class Property extends InteractionAffordance implements DataSchema {
     PrefixMapping prefixMapping,
   ) {
     final Set<String> parsedFields = {};
-    final observable = json.parseField<bool>('observable') ?? false;
-    final dataSchema =
-        DataSchema.fromJson(json, {'observable', 'uriVariables'});
-    final uriVariables = json.parseMapField<dynamic>('uriVariables');
+    final observable =
+        json.parseField<bool>('observable', parsedFields) ?? false;
+    final uriVariables =
+        json.parseMapField<dynamic>('uriVariables', parsedFields);
+    final dataSchema = DataSchema.fromJson(json, prefixMapping, parsedFields);
 
     final property = Property(
       thingDescription,
@@ -43,7 +44,13 @@ class Property extends InteractionAffordance implements DataSchema {
       uriVariables: uriVariables,
     );
 
-    property.forms.addAll(json.parseForms(property, prefixMapping));
+    property.forms.addAll(
+      json.parseAffordanceForms(
+        property,
+        prefixMapping,
+        parsedFields,
+      ),
+    );
     property.additionalFields.addAll(
       json.parseAdditionalFields(prefixMapping, parsedFields),
     );

--- a/lib/src/definitions/link.dart
+++ b/lib/src/definitions/link.dart
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:curie/curie.dart';
+
 import 'extensions/json_parser.dart';
 
 /// Represents an element of the `links` array in a Thing Description.
@@ -29,7 +31,7 @@ class Link {
   }
 
   /// Creates a new [Link] from a [json] object.
-  Link.fromJson(Map<String, dynamic> json) {
+  Link.fromJson(Map<String, dynamic> json, PrefixMapping prefixMapping) {
     final Set<String> parsedFields = {};
 
     href = json.parseRequiredUriField('href', parsedFields);
@@ -40,11 +42,8 @@ class Link {
     sizes = json.parseField<String>('sizes', parsedFields);
     hreflang = json.parseArrayField<String>('hreflang', parsedFields);
 
-    additionalFields.addAll(
-      Map.fromEntries(
-        json.entries.where((element) => !parsedFields.contains(element.key)),
-      ),
-    );
+    additionalFields
+        .addAll(json.parseAdditionalFields(prefixMapping, parsedFields));
   }
 
   /// Target IRI of a link or submission target of a form.

--- a/lib/src/definitions/link.dart
+++ b/lib/src/definitions/link.dart
@@ -32,7 +32,7 @@ class Link {
   Link.fromJson(Map<String, dynamic> json) {
     final Set<String> parsedFields = {};
 
-    href = Uri.parse(json.parseRequiredField<String>('href', parsedFields));
+    href = json.parseRequiredUriField('href', parsedFields);
     type = json.parseField<String>('@type', parsedFields);
     rel = json.parseField<String>('rel', parsedFields);
     anchor =

--- a/lib/src/definitions/security/ace_security_scheme.dart
+++ b/lib/src/definitions/security/ace_security_scheme.dart
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:curie/curie.dart';
+
 import '../extensions/json_parser.dart';
 
 import 'security_scheme.dart';
@@ -24,7 +26,10 @@ class AceSecurityScheme extends SecurityScheme {
   }
 
   /// Creates an [AceSecurityScheme] from a [json] object.
-  AceSecurityScheme.fromJson(Map<String, dynamic> json) {
+  AceSecurityScheme.fromJson(
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping,
+  ) {
     final Set<String> parsedFields = {};
 
     as = json.parseField<String>('ace:as', parsedFields);
@@ -32,7 +37,7 @@ class AceSecurityScheme extends SecurityScheme {
     audience = json.parseField<String>('ace:audience', parsedFields);
     scopes = json.parseArrayField<String>('ace:scopes', parsedFields);
 
-    parseSecurityJson(json, parsedFields);
+    parseSecurityJson(json, parsedFields, prefixMapping);
   }
 
   @override

--- a/lib/src/definitions/security/ace_security_scheme.dart
+++ b/lib/src/definitions/security/ace_security_scheme.dart
@@ -20,7 +20,7 @@ class AceSecurityScheme extends SecurityScheme {
     this.scopes,
     this.cnonce,
     Map<String, String>? descriptions,
-  }) {
+  }) : super('ace:ACESecurityScheme') {
     this.description = description;
     this.descriptions.addAll(descriptions ?? {});
   }
@@ -29,7 +29,7 @@ class AceSecurityScheme extends SecurityScheme {
   AceSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) {
+  ) : super('ace:ACESecurityScheme') {
     final Set<String> parsedFields = {};
 
     as = json.parseField<String>('ace:as', parsedFields);
@@ -39,9 +39,6 @@ class AceSecurityScheme extends SecurityScheme {
 
     parseSecurityJson(json, parsedFields, prefixMapping);
   }
-
-  @override
-  String get scheme => 'ace:ACESecurityScheme';
 
   /// URI of the authorization server.
   String? as;

--- a/lib/src/definitions/security/apikey_security_scheme.dart
+++ b/lib/src/definitions/security/apikey_security_scheme.dart
@@ -21,13 +21,14 @@ class ApiKeySecurityScheme extends SecurityScheme {
     this.name,
     String? in_,
     super.descriptions,
-  }) : in_ = in_ ?? _defaultInValue;
+  })  : in_ = in_ ?? _defaultInValue,
+        super('apikey');
 
   /// Creates a [ApiKeySecurityScheme] from a [json] object.
   ApiKeySecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) {
+  ) : super('apikey') {
     final Set<String> parsedFields = {};
 
     name = json.parseField<String>('name', parsedFields);
@@ -35,9 +36,6 @@ class ApiKeySecurityScheme extends SecurityScheme {
 
     parseSecurityJson(json, parsedFields, prefixMapping);
   }
-
-  @override
-  String get scheme => 'apikey';
 
   /// Name for query, header, cookie, or uri parameters.
   String? name;

--- a/lib/src/definitions/security/apikey_security_scheme.dart
+++ b/lib/src/definitions/security/apikey_security_scheme.dart
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:curie/curie.dart';
+
 import '../extensions/json_parser.dart';
 import 'security_scheme.dart';
 
@@ -22,13 +24,16 @@ class ApiKeySecurityScheme extends SecurityScheme {
   }) : in_ = in_ ?? _defaultInValue;
 
   /// Creates a [ApiKeySecurityScheme] from a [json] object.
-  ApiKeySecurityScheme.fromJson(Map<String, dynamic> json) {
+  ApiKeySecurityScheme.fromJson(
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping,
+  ) {
     final Set<String> parsedFields = {};
 
     name = json.parseField<String>('name', parsedFields);
     in_ = json.parseField<String>('in', parsedFields) ?? _defaultInValue;
 
-    parseSecurityJson(json, parsedFields);
+    parseSecurityJson(json, parsedFields, prefixMapping);
   }
 
   @override

--- a/lib/src/definitions/security/auto_security_scheme.dart
+++ b/lib/src/definitions/security/auto_security_scheme.dart
@@ -4,14 +4,19 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:curie/curie.dart';
+
 import 'security_scheme.dart';
 
 /// An automatic security configuration identified by the
 /// vocabulary term `auto`.
 class AutoSecurityScheme extends SecurityScheme {
   /// Creates an [AutoSecurityScheme] from a [json] object.
-  AutoSecurityScheme.fromJson(Map<String, dynamic> json) {
-    parseSecurityJson(json, {});
+  AutoSecurityScheme.fromJson(
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping,
+  ) {
+    parseSecurityJson(json, {}, prefixMapping);
   }
 
   @override

--- a/lib/src/definitions/security/auto_security_scheme.dart
+++ b/lib/src/definitions/security/auto_security_scheme.dart
@@ -15,10 +15,7 @@ class AutoSecurityScheme extends SecurityScheme {
   AutoSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) {
+  ) : super('auto') {
     parseSecurityJson(json, {}, prefixMapping);
   }
-
-  @override
-  String get scheme => 'auto';
 }

--- a/lib/src/definitions/security/basic_security_scheme.dart
+++ b/lib/src/definitions/security/basic_security_scheme.dart
@@ -21,13 +21,14 @@ class BasicSecurityScheme extends SecurityScheme {
     this.name,
     String? in_,
     super.descriptions,
-  }) : in_ = in_ ?? _defaultInValue;
+  })  : in_ = in_ ?? _defaultInValue,
+        super('basic');
 
   /// Creates a [BasicSecurityScheme] from a [json] object.
   BasicSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) {
+  ) : super('basic') {
     final Set<String> parsedFields = {};
 
     name = json.parseField<String>('name', parsedFields);
@@ -35,9 +36,6 @@ class BasicSecurityScheme extends SecurityScheme {
 
     parseSecurityJson(json, parsedFields, prefixMapping);
   }
-
-  @override
-  String get scheme => 'basic';
 
   /// Name for query, header, cookie, or uri parameters.
   late final String? name;

--- a/lib/src/definitions/security/basic_security_scheme.dart
+++ b/lib/src/definitions/security/basic_security_scheme.dart
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:curie/curie.dart';
+
 import '../extensions/json_parser.dart';
 import 'security_scheme.dart';
 
@@ -22,13 +24,16 @@ class BasicSecurityScheme extends SecurityScheme {
   }) : in_ = in_ ?? _defaultInValue;
 
   /// Creates a [BasicSecurityScheme] from a [json] object.
-  BasicSecurityScheme.fromJson(Map<String, dynamic> json) {
+  BasicSecurityScheme.fromJson(
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping,
+  ) {
     final Set<String> parsedFields = {};
 
     name = json.parseField<String>('name', parsedFields);
     in_ = json.parseField<String>('in', parsedFields) ?? _defaultInValue;
 
-    parseSecurityJson(json, parsedFields);
+    parseSecurityJson(json, parsedFields, prefixMapping);
   }
 
   @override

--- a/lib/src/definitions/security/bearer_security_scheme.dart
+++ b/lib/src/definitions/security/bearer_security_scheme.dart
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:curie/curie.dart';
+
 import '../extensions/json_parser.dart';
 import 'security_scheme.dart';
 
@@ -29,7 +31,10 @@ class BearerSecurityScheme extends SecurityScheme {
         format = format ?? _defaultFormatValue;
 
   /// Creates a [BearerSecurityScheme] from a [json] object.
-  BearerSecurityScheme.fromJson(Map<String, dynamic> json) {
+  BearerSecurityScheme.fromJson(
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping,
+  ) {
     final Set<String> parsedFields = {};
 
     name = json.parseField<String>('name', parsedFields);
@@ -39,7 +44,7 @@ class BearerSecurityScheme extends SecurityScheme {
     alg = json.parseField<String>('alg', parsedFields) ?? _defaultAlgValue;
     authorization = json.parseField<String>('authorization', parsedFields);
 
-    parseSecurityJson(json, parsedFields);
+    parseSecurityJson(json, parsedFields, prefixMapping);
   }
 
   @override

--- a/lib/src/definitions/security/bearer_security_scheme.dart
+++ b/lib/src/definitions/security/bearer_security_scheme.dart
@@ -28,13 +28,14 @@ class BearerSecurityScheme extends SecurityScheme {
     super.descriptions,
   })  : in_ = in_ ?? _defaultInValue,
         alg = alg ?? _defaultAlgValue,
-        format = format ?? _defaultFormatValue;
+        format = format ?? _defaultFormatValue,
+        super('bearer');
 
   /// Creates a [BearerSecurityScheme] from a [json] object.
   BearerSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) {
+  ) : super('bearer') {
     final Set<String> parsedFields = {};
 
     name = json.parseField<String>('name', parsedFields);
@@ -46,9 +47,6 @@ class BearerSecurityScheme extends SecurityScheme {
 
     parseSecurityJson(json, parsedFields, prefixMapping);
   }
-
-  @override
-  String get scheme => 'bearer';
 
   /// URI of the authorization server.
   late final String? authorization;

--- a/lib/src/definitions/security/digest_security_scheme.dart
+++ b/lib/src/definitions/security/digest_security_scheme.dart
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:curie/curie.dart';
+
 import '../extensions/json_parser.dart';
 import 'security_scheme.dart';
 
@@ -26,14 +28,17 @@ class DigestSecurityScheme extends SecurityScheme {
         qop = qop ?? _defaultQoPValue;
 
   /// Creates a [DigestSecurityScheme] from a [json] object.
-  DigestSecurityScheme.fromJson(Map<String, dynamic> json) {
+  DigestSecurityScheme.fromJson(
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping,
+  ) {
     final Set<String> parsedFields = {};
 
     name = json.parseField<String>('name', parsedFields);
     in_ = json.parseField<String>('in', parsedFields) ?? _defaultInValue;
     qop = json.parseField<String>('qop', parsedFields) ?? _defaultInValue;
 
-    parseSecurityJson(json, parsedFields);
+    parseSecurityJson(json, parsedFields, prefixMapping);
   }
 
   @override

--- a/lib/src/definitions/security/digest_security_scheme.dart
+++ b/lib/src/definitions/security/digest_security_scheme.dart
@@ -25,13 +25,14 @@ class DigestSecurityScheme extends SecurityScheme {
     this.name,
     super.descriptions,
   })  : in_ = in_ ?? _defaultInValue,
-        qop = qop ?? _defaultQoPValue;
+        qop = qop ?? _defaultQoPValue,
+        super('digest');
 
   /// Creates a [DigestSecurityScheme] from a [json] object.
   DigestSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) {
+  ) : super('digest') {
     final Set<String> parsedFields = {};
 
     name = json.parseField<String>('name', parsedFields);
@@ -40,9 +41,6 @@ class DigestSecurityScheme extends SecurityScheme {
 
     parseSecurityJson(json, parsedFields, prefixMapping);
   }
-
-  @override
-  String get scheme => 'digest';
 
   /// Name for query, header, cookie, or uri parameters.
   late final String? name;

--- a/lib/src/definitions/security/no_security_scheme.dart
+++ b/lib/src/definitions/security/no_security_scheme.dart
@@ -15,10 +15,7 @@ class NoSecurityScheme extends SecurityScheme {
   NoSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) {
+  ) : super('nosec') {
     parseSecurityJson(json, {}, prefixMapping);
   }
-
-  @override
-  String get scheme => 'nosec';
 }

--- a/lib/src/definitions/security/no_security_scheme.dart
+++ b/lib/src/definitions/security/no_security_scheme.dart
@@ -4,14 +4,19 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:curie/curie.dart';
+
 import 'security_scheme.dart';
 
 /// A security configuration corresponding to identified by the Vocabulary Term
 /// `nosec`.
 class NoSecurityScheme extends SecurityScheme {
   /// Creates a [NoSecurityScheme] from a [json] object.
-  NoSecurityScheme.fromJson(Map<String, dynamic> json) {
-    parseSecurityJson(json, {});
+  NoSecurityScheme.fromJson(
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping,
+  ) {
+    parseSecurityJson(json, {}, prefixMapping);
   }
 
   @override

--- a/lib/src/definitions/security/oauth2_security_scheme.dart
+++ b/lib/src/definitions/security/oauth2_security_scheme.dart
@@ -22,7 +22,7 @@ class OAuth2SecurityScheme extends SecurityScheme {
     this.refresh,
     this.token,
     Map<String, String>? descriptions,
-  }) {
+  }) : super('oauth2') {
     this.description = description;
     this.descriptions.addAll(descriptions ?? {});
   }
@@ -31,7 +31,7 @@ class OAuth2SecurityScheme extends SecurityScheme {
   OAuth2SecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) {
+  ) : super('oauth2') {
     final Set<String> parsedFields = {};
 
     authorization = json.parseField<String>('authorization', parsedFields);
@@ -42,8 +42,6 @@ class OAuth2SecurityScheme extends SecurityScheme {
 
     parseSecurityJson(json, parsedFields, prefixMapping);
   }
-  @override
-  String get scheme => 'oauth2';
 
   /// URI of the authorization server.
   ///

--- a/lib/src/definitions/security/oauth2_security_scheme.dart
+++ b/lib/src/definitions/security/oauth2_security_scheme.dart
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:curie/curie.dart';
+
 import '../extensions/json_parser.dart';
 import 'security_scheme.dart';
 
@@ -26,7 +28,10 @@ class OAuth2SecurityScheme extends SecurityScheme {
   }
 
   /// Creates a [OAuth2SecurityScheme] from a [json] object.
-  OAuth2SecurityScheme.fromJson(Map<String, dynamic> json) {
+  OAuth2SecurityScheme.fromJson(
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping,
+  ) {
     final Set<String> parsedFields = {};
 
     authorization = json.parseField<String>('authorization', parsedFields);
@@ -35,7 +40,7 @@ class OAuth2SecurityScheme extends SecurityScheme {
     scopes = json.parseArrayField<String>('scopes', parsedFields);
     flow = json.parseRequiredField<String>('flow', parsedFields);
 
-    parseSecurityJson(json, parsedFields);
+    parseSecurityJson(json, parsedFields, prefixMapping);
   }
   @override
   String get scheme => 'oauth2';

--- a/lib/src/definitions/security/psk_security_scheme.dart
+++ b/lib/src/definitions/security/psk_security_scheme.dart
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:curie/curie.dart';
+
 import '../extensions/json_parser.dart';
 import 'security_scheme.dart';
 
@@ -23,12 +25,15 @@ class PskSecurityScheme extends SecurityScheme {
   }
 
   /// Creates a [PskSecurityScheme] from a [json] object.
-  PskSecurityScheme.fromJson(Map<String, dynamic> json) {
+  PskSecurityScheme.fromJson(
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping,
+  ) {
     final Set<String> parsedFields = {};
 
     identity = json.parseField<String>('identity');
 
-    parseSecurityJson(json, parsedFields);
+    parseSecurityJson(json, parsedFields, prefixMapping);
   }
 
   @override

--- a/lib/src/definitions/security/psk_security_scheme.dart
+++ b/lib/src/definitions/security/psk_security_scheme.dart
@@ -18,7 +18,7 @@ class PskSecurityScheme extends SecurityScheme {
     String? description,
     String? proxy,
     Map<String, String>? descriptions,
-  }) {
+  }) : super('psk') {
     this.description = description;
     this.proxy = proxy;
     this.descriptions.addAll(descriptions ?? {});
@@ -28,16 +28,13 @@ class PskSecurityScheme extends SecurityScheme {
   PskSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) {
+  ) : super('psk') {
     final Set<String> parsedFields = {};
 
     identity = json.parseField<String>('identity');
 
     parseSecurityJson(json, parsedFields, prefixMapping);
   }
-
-  @override
-  String get scheme => 'psk';
 
   /// Name for query, header, cookie, or uri parameters.
   String? identity;

--- a/lib/src/definitions/security/security_scheme.dart
+++ b/lib/src/definitions/security/security_scheme.dart
@@ -21,7 +21,8 @@ import 'psk_security_scheme.dart';
 /// mechanism.
 abstract class SecurityScheme {
   /// Constructor.
-  SecurityScheme({
+  SecurityScheme(
+    this.scheme, {
     this.description,
     this.proxy,
     Map<String, String>? descriptions,
@@ -33,7 +34,7 @@ abstract class SecurityScheme {
   ///
   /// Can be one of `nosec`, `combo`, `basic`, `digest`, `bearer`, `psk`,
   /// `oauth2`, or `apikey`.
-  String get scheme;
+  final String scheme;
 
   /// The default [description] of this [SecurityScheme].
   String? description;

--- a/lib/src/definitions/security/security_scheme.dart
+++ b/lib/src/definitions/security/security_scheme.dart
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:curie/curie.dart';
+
 import '../extensions/json_parser.dart';
 import 'ace_security_scheme.dart';
 import 'apikey_security_scheme.dart';
@@ -52,6 +54,7 @@ abstract class SecurityScheme {
   void parseSecurityJson(
     Map<String, dynamic> json,
     Set<String> parsedFields,
+    PrefixMapping prefixMapping,
   ) {
     parsedFields.add('scheme');
 
@@ -61,32 +64,34 @@ abstract class SecurityScheme {
         .addAll(json.parseMapField<String>('descriptions', parsedFields) ?? {});
     jsonLdType = json.parseArrayField<String>('@type');
 
-    additionalFields.addEntries(
-      json.entries.where((jsonEntry) => !parsedFields.contains(jsonEntry.key)),
-    );
+    additionalFields
+        .addAll(json.parseAdditionalFields(prefixMapping, parsedFields));
   }
 
   /// Creates a [SecurityScheme] from a [json] object.
-  static SecurityScheme? fromJson(Map<String, dynamic> json) {
+  static SecurityScheme? fromJson(
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping,
+  ) {
     switch (json['scheme']) {
       case 'auto':
-        return AutoSecurityScheme.fromJson(json);
+        return AutoSecurityScheme.fromJson(json, prefixMapping);
       case 'basic':
-        return BasicSecurityScheme.fromJson(json);
+        return BasicSecurityScheme.fromJson(json, prefixMapping);
       case 'bearer':
-        return BearerSecurityScheme.fromJson(json);
+        return BearerSecurityScheme.fromJson(json, prefixMapping);
       case 'nosec':
-        return NoSecurityScheme.fromJson(json);
+        return NoSecurityScheme.fromJson(json, prefixMapping);
       case 'psk':
-        return PskSecurityScheme.fromJson(json);
+        return PskSecurityScheme.fromJson(json, prefixMapping);
       case 'digest':
-        return DigestSecurityScheme.fromJson(json);
+        return DigestSecurityScheme.fromJson(json, prefixMapping);
       case 'apikey':
-        return ApiKeySecurityScheme.fromJson(json);
+        return ApiKeySecurityScheme.fromJson(json, prefixMapping);
       case 'oauth2':
-        return OAuth2SecurityScheme.fromJson(json);
+        return OAuth2SecurityScheme.fromJson(json, prefixMapping);
       case 'ace:ACESecurityScheme':
-        return AceSecurityScheme.fromJson(json);
+        return AceSecurityScheme.fromJson(json, prefixMapping);
     }
 
     return null;

--- a/lib/src/definitions/thing_description.dart
+++ b/lib/src/definitions/thing_description.dart
@@ -158,18 +158,8 @@ class ThingDescription {
     if (events is Map<String, dynamic>) {
       _parseEvents(events);
     }
-    final dynamic links = json['links'];
-    if (links is List<dynamic>) {
-      _parseLinks(links);
-    }
-  }
 
-  void _parseLinks(List<dynamic> json) {
-    for (final link in json) {
-      if (link is Map<String, dynamic>) {
-        links.add(Link.fromJson(link));
-      }
-    }
+    links.addAll(json.parseLinks(prefixMapping) ?? []);
   }
 
   void _parseProperties(Map<String, dynamic> json) {

--- a/lib/src/definitions/thing_description.dart
+++ b/lib/src/definitions/thing_description.dart
@@ -139,66 +139,16 @@ class ThingDescription {
     security
         .addAll(json.parseArrayField<String>('security', parsedFields) ?? []);
 
-    final dynamic securityDefinitions = json['securityDefinitions'];
-    if (securityDefinitions is Map<String, dynamic>) {
-      _parseSecurityDefinitions(securityDefinitions);
-    }
+    securityDefinitions.addAll(
+      json.parseSecurityDefinitions(prefixMapping, parsedFields) ?? {},
+    );
 
     uriVariables = json.parseMapField<dynamic>('uriVariables');
 
-    final dynamic properties = json['properties'];
-    if (properties is Map<String, dynamic>) {
-      _parseProperties(properties);
-    }
-    final dynamic actions = json['actions'];
-    if (actions is Map<String, dynamic>) {
-      _parseActions(actions);
-    }
-    final dynamic events = json['events'];
-    if (events is Map<String, dynamic>) {
-      _parseEvents(events);
-    }
+    properties.addAll(json.parseProperties(this, prefixMapping) ?? {});
+    actions.addAll(json.parseActions(this, prefixMapping) ?? {});
+    events.addAll(json.parseEvents(this, prefixMapping) ?? {});
 
     links.addAll(json.parseLinks(prefixMapping) ?? []);
-  }
-
-  void _parseProperties(Map<String, dynamic> json) {
-    for (final property in json.entries) {
-      final dynamic value = property.value;
-      if (value is Map<String, dynamic>) {
-        properties[property.key] =
-            Property.fromJson(value, this, prefixMapping);
-      }
-    }
-  }
-
-  void _parseActions(Map<String, dynamic> json) {
-    for (final action in json.entries) {
-      final dynamic value = action.value;
-      if (value is Map<String, dynamic>) {
-        actions[action.key] = Action.fromJson(value, this, prefixMapping);
-      }
-    }
-  }
-
-  void _parseEvents(Map<String, dynamic> json) {
-    for (final event in json.entries) {
-      final dynamic value = event.value;
-      if (value is Map<String, dynamic>) {
-        events[event.key] = Event.fromJson(value, this, prefixMapping);
-      }
-    }
-  }
-
-  void _parseSecurityDefinitions(Map<String, dynamic> json) {
-    for (final securityDefinition in json.entries) {
-      final dynamic value = securityDefinition.value;
-      if (value is Map<String, dynamic>) {
-        final securityScheme = SecurityScheme.fromJson(value);
-        if (securityScheme != null) {
-          securityDefinitions[securityDefinition.key] = securityScheme;
-        }
-      }
-    }
   }
 }

--- a/lib/src/definitions/thing_description.dart
+++ b/lib/src/definitions/thing_description.dart
@@ -135,7 +135,7 @@ class ThingDescription {
     descriptions
         .addAll(json.parseMapField<String>('descriptions', parsedFields) ?? {});
     id = json.parseField<String>('id', parsedFields);
-    base = Uri.tryParse(json.parseField<String>('base', parsedFields) ?? '');
+    base = json.parseUriField('base', parsedFields);
     security
         .addAll(json.parseArrayField<String>('security', parsedFields) ?? []);
 

--- a/lib/src/definitions/thing_description.dart
+++ b/lib/src/definitions/thing_description.dart
@@ -193,11 +193,12 @@ class ThingDescription {
     );
     forms.addAll(json.parseForms(this, prefixMapping, parsedFields) ?? []);
 
-    properties.addAll(json.parseProperties(this, prefixMapping) ?? {});
-    actions.addAll(json.parseActions(this, prefixMapping) ?? {});
-    events.addAll(json.parseEvents(this, prefixMapping) ?? {});
+    properties
+        .addAll(json.parseProperties(this, prefixMapping, parsedFields) ?? {});
+    actions.addAll(json.parseActions(this, prefixMapping, parsedFields) ?? {});
+    events.addAll(json.parseEvents(this, prefixMapping, parsedFields) ?? {});
 
-    links.addAll(json.parseLinks(prefixMapping) ?? []);
+    links.addAll(json.parseLinks(prefixMapping, parsedFields) ?? []);
 
     profile.addAll(json.parseUriArrayField('profile', parsedFields) ?? []);
     schemaDefinitions.addAll(

--- a/lib/src/definitions/version_info.dart
+++ b/lib/src/definitions/version_info.dart
@@ -1,0 +1,45 @@
+import 'package:curie/curie.dart';
+
+import 'extensions/json_parser.dart';
+
+/// Metadata of a Thing that provides version information about the TD document.
+///
+/// If required, additional version information such as firmware and hardware
+/// version (term definitions outside of the TD namespace) can be extended via
+/// the TD Context Extension mechanism.
+class VersionInfo {
+  /// Constructor.
+  VersionInfo(
+    this.instance, {
+    this.model,
+    this.additionalFields,
+  });
+
+  /// Creates a new [VersionInfo] instance from a [json] object.
+  factory VersionInfo.fromJson(
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping,
+  ) {
+    final Set<String> parsedFields = {};
+
+    final instance = json.parseRequiredField<String>('instance', parsedFields);
+    final model = json.parseField<String>('instance', parsedFields);
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
+
+    return VersionInfo(
+      instance,
+      model: model,
+      additionalFields: additionalFields,
+    );
+  }
+
+  /// Provides a version indicator of this TD.
+  final String instance;
+
+  /// Provides a version indicator of the underlying TM.
+  final String? model;
+
+  /// Additional fields collected during the parsing of a JSON object.
+  final Map<String, dynamic>? additionalFields;
+}

--- a/test/core/content_serdes_test.dart
+++ b/test/core/content_serdes_test.dart
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'package:curie/curie.dart';
 import 'package:dart_wot/src/core/codecs/json_codec.dart';
 import 'package:dart_wot/src/core/content.dart';
 import 'package:dart_wot/src/core/content_serdes.dart';
@@ -25,8 +26,10 @@ void main() {
     final contentSerdes = ContentSerdes();
 
     final testContent1 = _getTestContent('42');
-    final successfulSchema =
-        DataSchema.fromJson(<String, dynamic>{'type': 'number'});
+    final successfulSchema = DataSchema.fromJson(
+      <String, dynamic>{'type': 'number'},
+      PrefixMapping(),
+    );
 
     expect(
       await contentSerdes.contentToValue(testContent1, successfulSchema),
@@ -34,8 +37,10 @@ void main() {
     );
 
     final testContent2 = _getTestContent('42');
-    final failingSchema =
-        DataSchema.fromJson(<String, dynamic>{'type': 'string'});
+    final failingSchema = DataSchema.fromJson(
+      <String, dynamic>{'type': 'string'},
+      PrefixMapping(),
+    );
 
     expect(
       contentSerdes.contentToValue(testContent2, failingSchema),

--- a/test/core/definitions_test.dart
+++ b/test/core/definitions_test.dart
@@ -110,6 +110,7 @@ void main() {
       final form3 = Form.fromJson(
         form3Json as Map<String, dynamic>,
         interactionAffordance,
+        PrefixMapping(),
       );
 
       expect(form3.href, uri);
@@ -142,6 +143,7 @@ void main() {
       final form4 = Form.fromJson(
         form4Json as Map<String, dynamic>,
         interactionAffordance,
+        PrefixMapping(),
       );
 
       expect(form4.op, [OperationType.writeproperty]);
@@ -157,6 +159,7 @@ void main() {
         () => Form.fromJson(
           form5Json as Map<String, dynamic>,
           interactionAffordance,
+          PrefixMapping(),
         ),
         throwsException,
       );
@@ -181,6 +184,7 @@ void main() {
       final form6 = Form.fromJson(
         form6Json as Map<String, dynamic>,
         interactionAffordance,
+        PrefixMapping(),
       );
 
       final additionalResponses = form6.additionalResponses;
@@ -478,16 +482,15 @@ void main() {
     expect(firstResponse.additionalFields['test'], 'test');
 
     final expectedResponseJson = {
-      'response': {
-        'contentType': 'application/json',
-        'test': 'test',
-      },
+      'contentType': 'application/json',
+      'test': 'test',
     };
 
-    final secondResponse = ExpectedResponse.fromJson(expectedResponseJson);
+    final secondResponse =
+        ExpectedResponse.fromJson(expectedResponseJson, PrefixMapping());
 
     expect(secondResponse, isA<ExpectedResponse>());
-    expect(secondResponse?.additionalFields['test'], 'test');
+    expect(secondResponse.additionalFields['test'], 'test');
   });
 
   test('Should reject invalid @context entries', () {

--- a/test/core/definitions_test.dart
+++ b/test/core/definitions_test.dart
@@ -24,7 +24,7 @@ import 'package:dart_wot/src/definitions/validation/validation_exception.dart';
 import 'package:test/test.dart';
 
 class _InvalidInteractionAffordance extends InteractionAffordance {
-  _InvalidInteractionAffordance(super.forms, super.thingDescription);
+  _InvalidInteractionAffordance(super.thingDescription);
 }
 
 void main() {
@@ -65,7 +65,7 @@ void main() {
 
     test('Form', () {
       final thingDescription = ThingDescription(null);
-      final interactionAffordance = Property([], thingDescription);
+      final interactionAffordance = Property(thingDescription);
 
       final uri = Uri.parse('https://example.org');
       final form = Form(uri, interactionAffordance);
@@ -198,7 +198,7 @@ void main() {
       expect(
         () => Form(
           Uri.parse('http://example.org'),
-          _InvalidInteractionAffordance([], thingDescription),
+          _InvalidInteractionAffordance(thingDescription),
         ),
         throwsStateError,
       );
@@ -258,6 +258,7 @@ void main() {
         },
         'properties': {
           'property': {
+            '@type': 'test',
             'title': 'Test',
             'titles': {'de': 'German Test', 'en': 'English Test'},
             'description': 'This is a Test',
@@ -270,10 +271,28 @@ void main() {
             'observable': true,
             'enum': ['On', 'Off', 3],
             'constant': 'On',
+            'default': 'On',
+            'unit': 'C',
+            'contentEncoding': 'test',
+            'contentMediaType': 'test',
             'type': 'string',
             'forms': [
               {'href': 'https://example.org'}
-            ]
+            ],
+            'format': 'test',
+            'pattern': 'test',
+            'items': [
+              {'type': 'integer'}
+            ],
+            'minLength': 2,
+            'maxLength': 5,
+            'minItems': 2,
+            'maxItems': 5,
+            'exclusiveMinimum': 3,
+            'exclusiveMaximum': 3,
+            'multipleOf': 1,
+            'minimum': 3,
+            'maximum': 3,
           },
           'propertyWithDefaults': {
             'forms': [
@@ -281,9 +300,11 @@ void main() {
             ]
           },
           'objectSchemeProperty': {
+            'type': 'object',
             'properties': {
               'test': {'type': 'string'}
             },
+            'required': ['test'],
             'forms': [
               {
                 'href': 'https://example.org',
@@ -311,6 +332,7 @@ void main() {
       expect(noSecurityScheme?.scheme, 'nosec');
 
       final property = thingDescription.properties['property'];
+      expect(property?.atType, ['test']);
       expect(property?.title, 'Test');
       expect(property?.description, 'This is a Test');
       expect(property?.descriptions?['es'], 'Esto es una prueba');
@@ -320,6 +342,22 @@ void main() {
       expect(property?.observable, true);
       expect(property?.enumeration, ['On', 'Off', 3]);
       expect(property?.constant, 'On');
+      expect(property?.defaultValue, 'On');
+      expect(property?.format, 'test');
+      expect(property?.pattern, 'test');
+      expect(property?.contentEncoding, 'test');
+      expect(property?.contentMediaType, 'test');
+      expect(property?.unit, 'C');
+      expect(property?.items?[0].type, 'integer');
+      expect(property?.minLength, 2);
+      expect(property?.maxLength, 5);
+      expect(property?.minItems, 2);
+      expect(property?.maxItems, 5);
+      expect(property?.exclusiveMinimum, 3);
+      expect(property?.exclusiveMaximum, 3);
+      expect(property?.minimum, 3);
+      expect(property?.maximum, 3);
+      expect(property?.multipleOf, 1);
 
       final propertyWithDefaults =
           thingDescription.properties['propertyWithDefaults'];
@@ -329,6 +367,8 @@ void main() {
 
       final objectSchemeProperty =
           thingDescription.properties['objectSchemeProperty'];
+      expect(objectSchemeProperty?.required, ['test']);
+      expect(objectSchemeProperty?.type, 'object');
 
       expect(objectSchemeProperty?.forms[0].security, ['auto_sc']);
       final autoSecurityScheme =

--- a/test/core/definitions_test.dart
+++ b/test/core/definitions_test.dart
@@ -6,11 +6,14 @@
 
 import 'dart:convert';
 
+import 'package:curie/curie.dart';
 import 'package:dart_wot/dart_wot.dart';
 import 'package:dart_wot/src/definitions/additional_expected_response.dart';
 import 'package:dart_wot/src/definitions/context_entry.dart';
 import 'package:dart_wot/src/definitions/data_schema.dart';
 import 'package:dart_wot/src/definitions/expected_response.dart';
+import 'package:dart_wot/src/definitions/extensions/json_parser.dart';
+import 'package:dart_wot/src/definitions/interaction_affordances/action.dart';
 import 'package:dart_wot/src/definitions/interaction_affordances/interaction_affordance.dart';
 import 'package:dart_wot/src/definitions/interaction_affordances/property.dart';
 import 'package:dart_wot/src/definitions/operation_type.dart';
@@ -198,6 +201,11 @@ void main() {
           _InvalidInteractionAffordance([], thingDescription),
         ),
         throwsStateError,
+      );
+      expect(
+        () => <String, dynamic>{}
+            .parseForms(Action(ThingDescription(null)), PrefixMapping()),
+        throwsA(isA<ValidationException>()),
       );
     });
 

--- a/test/core/definitions_test.dart
+++ b/test/core/definitions_test.dart
@@ -247,6 +247,7 @@ void main() {
         () => <String, dynamic>{}.parseAffordanceForms(
           Action(ThingDescription(null)),
           PrefixMapping(),
+          {},
         ),
         throwsA(isA<ValidationException>()),
       );


### PR DESCRIPTION
This PR applies a number of additional reworks to the `definitions` module. It applies a number of refactorings for a more elegant processing of JSON to the module's class system and adds missing fields to the classes, achieving a complete mapping of the WoT TD data structures. Furthermore, it improves the support for additional fields in the different TD subclasses and expansions via JSON-LD.