### PR TITLE
fix(definitions): add missing writeallproperties operation

### DIFF
--- a/lib/src/binding_coap/coap_extensions.dart
+++ b/lib/src/binding_coap/coap_extensions.dart
@@ -105,6 +105,7 @@ extension OperationTypeExtension on OperationType {
         return CoapRequestMethod.get;
       case OperationType.writeproperty:
       case OperationType.writemultipleproperties:
+      case OperationType.writeallproperties:
         return CoapRequestMethod.put;
       case OperationType.invokeaction:
         return CoapRequestMethod.post;

--- a/lib/src/definitions/operation_type.dart
+++ b/lib/src/definitions/operation_type.dart
@@ -34,6 +34,9 @@ enum OperationType {
   /// Corresponds with the `writemultipleproperties` operation type.
   writemultipleproperties,
 
+  /// Corresponds with the `writeallproperties` operation type.
+  writeallproperties,
+
   /// Corresponds with the `invokeaction` operation type.
   invokeaction,
 


### PR DESCRIPTION
For some reason, this operation type was missing from the `OperationType` enumeration.