### PR TITLE
feat!: improve multicast discovery with CoRE Link-Format

### DIFF
--- a/lib/src/binding_coap/coap_extensions.dart
+++ b/lib/src/binding_coap/coap_extensions.dart
@@ -154,6 +154,13 @@ extension ResponseExtension on CoapResponse {
     return Content(_contentType, _payloadStream);
   }
 
+  /// Extract the [Content] of this [CoapResponse].
+  DiscoveryContent determineDiscoveryContent(String scheme) {
+    // ignore: invalid_use_of_internal_member
+    final discoveryUri = Uri(scheme: scheme, host: source?.host);
+    return DiscoveryContent(_contentType, _payloadStream, discoveryUri);
+  }
+
   /// Checks the [code] of this [CoapResponse] and throws an [Exception] if it
   /// should indicate an error.
   void checkResponseCode() {

--- a/lib/src/binding_http/http_client.dart
+++ b/lib/src/binding_http/http_client.dart
@@ -299,21 +299,22 @@ class HttpClient extends ProtocolClient {
     throw UnimplementedError();
   }
 
-  Future<Content> _sendDiscoveryRequest(
+  Future<DiscoveryContent> _sendDiscoveryRequest(
     Request request, {
     required String acceptHeaderValue,
   }) async {
     request.headers['Accept'] = acceptHeaderValue;
     final response = await _client.send(request);
     final finalResponse = await _handleResponse(request, response);
-    return Content(
+    return DiscoveryContent(
       response.headers['Content-Type'] ?? acceptHeaderValue,
       finalResponse.stream,
+      request.url,
     );
   }
 
   @override
-  Stream<Content> discoverDirectly(
+  Stream<DiscoveryContent> discoverDirectly(
     Uri uri, {
     bool disableMulticast = false,
   }) async* {
@@ -326,7 +327,7 @@ class HttpClient extends ProtocolClient {
   }
 
   @override
-  Stream<Content> discoverWithCoreLinkFormat(Uri uri) async* {
+  Stream<DiscoveryContent> discoverWithCoreLinkFormat(Uri uri) async* {
     final request = Request(HttpRequestMethod.get.methodName, uri);
 
     final encodedLinks = await _sendDiscoveryRequest(

--- a/lib/src/binding_mqtt/mqtt_client.dart
+++ b/lib/src/binding_mqtt/mqtt_client.dart
@@ -199,14 +199,14 @@ class MqttClient extends ProtocolClient {
   }
 
   @override
-  Stream<Content> discoverDirectly(
+  Stream<DiscoveryContent> discoverDirectly(
     Uri uri, {
     bool disableMulticast = false,
   }) async* {
     final client = await _connect(uri, null);
     const discoveryTopic = 'wot/td/#';
 
-    final streamController = StreamController<Content>();
+    final streamController = StreamController<DiscoveryContent>();
 
     Timer(
       _mqttConfig.discoveryTimeout,
@@ -229,8 +229,13 @@ class MqttClient extends ProtocolClient {
           final publishedMessage = message.payload as MqttPublishMessage;
           final payload = publishedMessage.payload.message;
 
-          streamController
-              .add(Content(discoveryContentType, Stream.value(payload)));
+          streamController.add(
+            DiscoveryContent(
+              discoveryContentType,
+              Stream.value(payload),
+              uri,
+            ),
+          );
         }
       },
       cancelOnError: false,
@@ -240,7 +245,7 @@ class MqttClient extends ProtocolClient {
   }
 
   @override
-  Stream<Content> discoverWithCoreLinkFormat(Uri uri) {
+  Stream<DiscoveryContent> discoverWithCoreLinkFormat(Uri uri) {
     // TODO: implement discoverWithCoreLinkFormat
     throw UnimplementedError();
   }

--- a/lib/src/core/content.dart
+++ b/lib/src/core/content.dart
@@ -31,3 +31,27 @@ class Content {
     return buffer.buffer;
   }
 }
+
+/// [Content] specific for discovery.
+///
+/// Mostly used for being able to convert results from multicast discovery to
+/// unicast discovery operations.
+class DiscoveryContent extends Content {
+  /// Creates a new [Content] object from a media [type], a [body], and an
+  /// optional [sourceUri].
+  DiscoveryContent(
+    super.type,
+    super.body,
+    this.sourceUri,
+  );
+
+  /// Creates a new [DiscoveryContent] object from regular [Content] and a
+  /// [sourceUri].
+  DiscoveryContent.fromContent(Content content, this.sourceUri)
+      : super(content.type, content.body);
+
+  /// The source of this [DiscoveryContent].
+  ///
+  /// Relevant when following up to multicast discovery with a unicast request.
+  final Uri sourceUri;
+}

--- a/lib/src/core/protocol_interfaces/protocol_client.dart
+++ b/lib/src/core/protocol_interfaces/protocol_client.dart
@@ -21,7 +21,7 @@ abstract class ProtocolClient {
   ///
   /// Allows the caller to explicitly [disableMulticast], overriding the
   /// multicast settings in the config of the underlying binding implementation.
-  Stream<Content> discoverDirectly(
+  Stream<DiscoveryContent> discoverDirectly(
     Uri uri, {
     bool disableMulticast = false,
   });
@@ -41,7 +41,7 @@ abstract class ProtocolClient {
   ///
   /// [RFC 6690]: https://datatracker.ietf.org/doc/html/rfc6690
   /// [RFC 9176]: https://datatracker.ietf.org/doc/html/rfc9176
-  Stream<Content> discoverWithCoreLinkFormat(Uri uri);
+  Stream<DiscoveryContent> discoverWithCoreLinkFormat(Uri uri);
 
   /// Requests the client to perform a `readproperty` operation on a [form].
   Future<Content> readResource(Form form);


### PR DESCRIPTION
I noticed a couple of issues when trying to use CoAP multicast for discovery from `/.well-known/core`. This PR provides a fix by introducing a subclass of `Content` called `DiscoveryContent` which makes it possible to follow up to a multicast request with a unicast request.