### PR TITLE
feat!: update `coap` dependency, fix example

### DIFF
--- a/example/coaps_readproperty.dart
+++ b/example/coaps_readproperty.dart
@@ -29,8 +29,11 @@ PskCredentials? _pskCredentialsCallback(
 }
 
 Future<void> main(List<String> args) async {
-  final CoapClientFactory coapClientFactory =
-      CoapClientFactory(CoapConfig(useTinyDtls: true));
+  final CoapClientFactory coapClientFactory = CoapClientFactory(
+    CoapConfig(
+      dtlsCiphers: 'PSK-AES128-CCM8',
+    ),
+  );
   final securityProvider =
       ClientSecurityProvider(pskCredentialsCallback: _pskCredentialsCallback);
   final servient = Servient(clientSecurityProvider: securityProvider)

--- a/lib/src/binding_coap/coap_config.dart
+++ b/lib/src/binding_coap/coap_config.dart
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import 'dart:typed_data';
+
 /// Allows for configuring the behavior of CoAP clients and servers.
 class CoapConfig {
   /// Creates a new [CoapConfig] object.
@@ -11,11 +13,25 @@ class CoapConfig {
     this.port = 5683,
     this.securePort = 5684,
     this.blocksize,
-    this.useTinyDtls = false,
-    this.useOpenSsl = false,
     this.allowMulticastDiscovery = false,
     this.multicastDiscoveryTimeout = const Duration(minutes: 60),
+    this.dtlsCiphers,
+    this.rootCertificates = const [],
+    this.dtlsWithTrustedRoots = true,
+    this.dtlsVerify = true,
   });
+
+  /// Whether certificates should be verified by OpenSSL.
+  final bool dtlsVerify;
+
+  /// Whether OpenSSL should be used with trusted Root Certificates.
+  final bool dtlsWithTrustedRoots;
+
+  /// Can be used to specify the Ciphers that should be used by OpenSSL.
+  final String? dtlsCiphers;
+
+  /// List of custom root certificates to use with OpenSSL.
+  final List<Uint8List> rootCertificates;
 
   /// The port number used by a client or server. Defaults to 5683.
   final int port;
@@ -25,12 +41,6 @@ class CoapConfig {
 
   /// The preferred block size for blockwise transfer.
   final int? blocksize;
-
-  /// Indicates if tinydtls is available as a DTLS backend.
-  final bool useTinyDtls;
-
-  /// Indicates if openSSL is available as a DTLS backend.
-  final bool useOpenSsl;
 
   /// Indicates if multicast should be available for discovery.
   ///

--- a/lib/src/binding_coap/coap_extensions.dart
+++ b/lib/src/binding_coap/coap_extensions.dart
@@ -190,14 +190,7 @@ extension OperationTypeExtension on OperationType {
 
 /// Extension for easily extracting the [content] from a [CoapResponse].
 extension ResponseExtension on CoapResponse {
-  Stream<List<int>> get _payloadStream {
-    final payload = this.payload;
-    if (payload != null) {
-      return Stream.value(payload);
-    } else {
-      return const Stream.empty();
-    }
-  }
+  Stream<List<int>> get _payloadStream => Stream.value(payload);
 
   String get _contentType =>
       contentFormat?.contentType.toString() ?? 'application/json';
@@ -238,8 +231,7 @@ extension ResponseExtension on CoapResponse {
 
     final responsePayload = payload;
 
-    if (responsePayload != null &&
-        contentFormat == CoapMediaType.applicationAceCbor &&
+    if (contentFormat == CoapMediaType.applicationAceCbor &&
         unauthorizedAceCodes.contains(contentFormat)) {
       return AuthServerRequestCreationHint.fromSerialized(
         responsePayload.toList(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: '>=2.17.0 <3.0.0'
 
 dev_dependencies:
-  build_runner: ^2.1.7
+  build_runner: ^2.3.0
   coverage: ^1.0.4
   dart_code_metrics: ^5.4.0
   lint: ^2.0.1
@@ -17,7 +17,7 @@ dev_dependencies:
 
 dependencies:
   cbor: ^5.1.2
-  coap: ^7.0.0
+  coap: ^8.0.0
   collection: ^1.16.0
   curie: ^0.1.0
   dcaf: ^0.1.0


### PR DESCRIPTION
This PR updates the `coap` package to the latest version, which removes `dart_tinydtls` as dependency. While the general feature set stays the same, it implies a breaking change since config parameters need to be changed and (due to a bug in the `dtls2` package) the subset of available ciphers needs to be adjusted.