### PR TITLE
style: fix formatting of mocked classes

### DIFF
--- a/test/binding_coap/binding_coap_test.mocks.dart
+++ b/test/binding_coap/binding_coap_test.mocks.dart
@@ -18,8 +18,8 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 
-class _FakeThingDescription_0 extends _i1.Fake implements _i2.ThingDescription {
-}
+class _FakeThingDescription_0 extends _i1.Fake
+    implements _i2.ThingDescription {}
 
 /// A class which mocks [ExposedThing].
 ///

--- a/test/binding_http/http_test.mocks.dart
+++ b/test/binding_http/http_test.mocks.dart
@@ -18,8 +18,8 @@ import 'package:mockito/mockito.dart' as _i1;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 
-class _FakeThingDescription_0 extends _i1.Fake implements _i2.ThingDescription {
-}
+class _FakeThingDescription_0 extends _i1.Fake
+    implements _i2.ThingDescription {}
 
 /// A class which mocks [ExposedThing].
 ///


### PR DESCRIPTION
This trivial PR fixes a linting problem that occurs with the current Dart version.