### PR TITLE
chore: simplify code coverage generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,11 @@ jobs:
         run: dart analyze
 
       - name: Run tests with coverage
-        run: dart test --coverage="coverage"
-
-      - name: Convert coverage to ICOV
-        run: dart run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --report-on=lib
+        run: dart run coverage:test_with_coverage
 
       - uses: codecov/codecov-action@v2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: coverage.lcov
+          file: coverage/lcov.info
           name: Upload to codecov.io
           verbose: true


### PR DESCRIPTION
I noticed that the code coverage report generation can be done in only line. This PR applies the change to the CI.