### PR TITLE
feat!: rework discovery API

### DIFF
--- a/example/coap_discovery.dart
+++ b/example/coap_discovery.dart
@@ -33,13 +33,11 @@ Future<void> main(List<String> args) async {
   final servient = Servient()..addClientFactory(CoapClientFactory());
 
   final wot = await servient.start();
-  final thingFilter = ThingFilter(
-    url: Uri.parse('coap://plugfest.thingweb.io:5683/testthing'),
-  );
+  final uri = Uri.parse('coap://plugfest.thingweb.io:5683/testthing');
 
   // Example using for-await-loop
   try {
-    await for (final thingDescription in wot.discover(thingFilter)) {
+    await for (final thingDescription in wot.discover(uri)) {
       await handleThingDescription(wot, thingDescription);
     }
     print('Discovery with "await for" has finished.');
@@ -51,7 +49,7 @@ Future<void> main(List<String> args) async {
   //
   // Notice how the "onDone" callback is called before the result is passed
   // to the handleThingDescription function.
-  wot.discover(thingFilter).listen(
+  wot.discover(uri).listen(
     (thingDescription) async {
       await handleThingDescription(wot, thingDescription);
     },

--- a/example/complex_example.dart
+++ b/example/complex_example.dart
@@ -163,7 +163,7 @@ Future<void> main() async {
     '/Oracle/oracle-Festo_Shared.td.jsonld',
   );
 
-  final thingDiscovery = wot.discover(ThingFilter(url: thingUri));
+  final thingDiscovery = wot.discover(thingUri);
 
   await for (final thingDescription in thingDiscovery) {
     final consumedDiscoveredThing = await wot.consume(thingDescription);

--- a/example/core_link_format_discovery.dart
+++ b/example/core_link_format_discovery.dart
@@ -20,10 +20,9 @@ Future<void> main(List<String> args) async {
   //              to TDs. At the moment, this URI is just for illustrative
   //              purpose and will not return actual Thing Description links.
   final discoveryUri = Uri.parse('coap://coap.me/.well-known/core');
-  final thingFilter =
-      ThingFilter(url: discoveryUri, method: DiscoveryMethod.coreLinkFormat);
 
-  await for (final thingDescription in wot.discover(thingFilter)) {
+  await for (final thingDescription
+      in wot.discover(discoveryUri, method: DiscoveryMethod.coreLinkFormat)) {
     final consumedThing = await wot.consume(thingDescription);
 
     try {

--- a/example/example.dart
+++ b/example/example.dart
@@ -107,7 +107,7 @@ Future<void> main(List<String> args) async {
     '/Oracle/oracle-Festo_Shared.td.jsonld',
   );
 
-  final thingDiscovery = wot.discover(ThingFilter(url: thingUri));
+  final thingDiscovery = wot.discover(thingUri);
 
   await for (final thingDescription in thingDiscovery) {
     final consumedDiscoveredThing = await wot.consume(thingDescription);

--- a/lib/src/core/wot.dart
+++ b/lib/src/core/wot.dart
@@ -6,6 +6,7 @@
 
 import '../../scripting_api.dart' as scripting_api;
 import '../definitions/thing_description.dart';
+import '../scripting_api/discovery/discovery_method.dart';
 import 'consumed_thing.dart';
 import 'exposed_thing.dart';
 import 'servient.dart';
@@ -81,9 +82,12 @@ class WoT implements scripting_api.WoT {
     }
   }
 
-  /// Discovers [ThingDescription]s matching a given [filter].
   @override
-  ThingDiscovery discover(scripting_api.ThingFilter filter) {
-    return ThingDiscovery(filter, _servient);
+  ThingDiscovery discover(
+    Uri url, {
+    scripting_api.ThingFilter? thingFilter,
+    DiscoveryMethod method = DiscoveryMethod.direct,
+  }) {
+    return ThingDiscovery(url, thingFilter, _servient, method: method);
   }
 }

--- a/lib/src/scripting_api/discovery/thing_discovery.dart
+++ b/lib/src/scripting_api/discovery/thing_discovery.dart
@@ -14,7 +14,7 @@ import 'thing_filter.dart';
 ///       to discovery.
 abstract class ThingDiscovery implements Stream<ThingDescription> {
   /// The [thingFilter] that is applied during the discovery process.
-  ThingFilter get thingFilter;
+  ThingFilter? get thingFilter;
 
   /// Indicates if this [ThingDiscovery] object is active.
   bool get active;

--- a/lib/src/scripting_api/discovery/thing_filter.dart
+++ b/lib/src/scripting_api/discovery/thing_filter.dart
@@ -4,37 +4,16 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'discovery_method.dart';
-
 /// Contains the constraints for discovering Things as key-value pairs.
 ///
 /// See [WoT Scripting API Specification, Section 10.3][spec link].
 ///
-/// Note that the default method here is set to [DiscoveryMethod.direct] instead
-/// of [DiscoveryMethod.directory], contrary to the Scripting API specification.
-/// This might change in future versions, depending on how his part of the
-/// specification is going to evolve.
-///
 /// [spec link]: https://w3c.github.io/wot-scripting-api/#the-thingfilter-dictionary
 class ThingFilter {
   /// Constructor.
-  ThingFilter({
-    required this.url,
-    this.method = DiscoveryMethod.direct,
-    this.fragment,
-  });
-
-  /// Represents the discovery type that should be used in the discovery process
-  DiscoveryMethod method;
-
-  /// Represents the URL of the target entity serving the discovery request.
-  ///
-  /// This is, for instance the URL of a Thing Directory (if [method] is
-  /// [DiscoveryMethod.directory]), or the URL of a directly targeted Thing (if
-  /// [method] is [DiscoveryMethod.direct]).
-  Uri url;
+  ThingFilter(this.fragment);
 
   /// Represents a template object used for matching property by property
   /// against discovered Things.
-  Map<String, dynamic>? fragment;
+  Map<String, dynamic> fragment;
 }

--- a/lib/src/scripting_api/wot.dart
+++ b/lib/src/scripting_api/wot.dart
@@ -6,6 +6,7 @@
 
 import '../definitions/thing_description.dart';
 import 'consumed_thing.dart';
+import 'discovery/discovery_method.dart';
 import 'discovery/thing_discovery.dart';
 import 'discovery/thing_filter.dart';
 import 'exposed_thing.dart';
@@ -30,28 +31,28 @@ abstract class WoT {
   /// based on the underlying impementation.
   Future<ExposedThing> produce(ExposedThingInit exposedThingInit);
 
-  /// Discovers [ThingDescription]s which can be obtained by calling `next()`
-  /// on the returned [ThingDiscovery] object.
+  /// Discovers [ThingDescription]s from a given [url] using the specified
+  /// [method].
   ///
   /// As this part of the Scripting API specification is still in development,
   /// this method's implementation is in an experimental state and does not
   /// conform to the specification's latest version.
   ///
-  /// A [thingFilter] has to be passed for filtering out TDs before they
-  /// are processed. The [thingFilter] also contains relevant information for
-  /// controlling the Discovery process, e. g. a URL, the discovery method
-  /// (`direct` or `directory`), and an optional `fragment` [Map] for filtering
-  /// out properties of a [ThingDescription].
+  /// A [thingFilter] may be passed for filtering out TDs before they
+  /// are processed.
+  /// However, since the semantics of the [ThingFilter] are not well-defined in
+  /// the Scripting API document, this parameter does not have an effect yet.
   ///
-  /// So far, however, only `direct` discovery is supported. Therefore, despite
-  /// its method signature, a compatible [ThingFilter] with a defined URL is
-  /// required. Also, handling the fragment map is not yet supported.
-  ///
-  /// The [ThingDiscovery] object that is returned by this function can be used
-  /// for stopping the Discovery process and retrieving information about its
-  /// current state (i.e., whether it is still `active`). It implements the
-  /// [Stream] interface, which makes it possible to `listen` for discovered
-  /// [ThingDescription]s or to iterate over the discovered results using the
-  /// `await for` syntax.
-  ThingDiscovery discover(ThingFilter thingFilter);
+  /// The [ThingDiscovery] object that is returned by this function implements
+  /// the  [Stream] interface, which makes it possible to `listen` for
+  /// discovered [ThingDescription]s or to iterate over the discovered results
+  /// using the `await for` syntax.
+  /// It also allows for stopping the Discovery process prematurely and
+  /// for retrieving information about its current state (i.e., whether it is
+  /// still `active`).
+  ThingDiscovery discover(
+    Uri url, {
+    ThingFilter? thingFilter,
+    DiscoveryMethod method = DiscoveryMethod.direct,
+  });
 }


### PR DESCRIPTION
This PR reworks the discovery API slightly (but in a breaking way), moving the `uri` argument from the `ThingFilter` class to the `discover` method itself.

There will probably another round of breaking changes once the discovery API in the Scripting API specification has been finalized, but this change should already be a significant improvement.