### PR TITLE
chore(ci): enable GitHub Actions for merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  merge_group:
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
This PR should make it possible to properly use the new merge queue feature.