### PR TITLE
fix(discovery): extract port from DNS SRV records

### DIFF
--- a/lib/src/core/thing_discovery.dart
+++ b/lib/src/core/thing_discovery.dart
@@ -297,6 +297,7 @@ class ThingDiscovery extends Stream<ThingDescription>
 
         final uri = Uri(
           host: srv.target,
+          port: srv.port,
           path: txtRecords['td'],
           scheme: txtRecords['scheme'] ?? defaultScheme,
         );


### PR DESCRIPTION
The port number from SRV records was previously not extracted from SRV records when using DNS-based Service Discovery. This PR fixes the issue.