### PR TITLE
feat(binding-coap)!: use blockSize instead of blockSZX

### DIFF
--- a/lib/src/binding_coap/coap_extensions.dart
+++ b/lib/src/binding_coap/coap_extensions.dart
@@ -100,10 +100,10 @@ extension CoapFormExtension on Form {
   }
 
   /// Indicates the Block2 size preferred by a server.
-  BlockSize? get block2Size => _determineBlockSize('block2SZX');
+  BlockSize? get block2Size => _determineBlockSize('block2Size');
 
   /// Indicates the Block1 size preferred by a server.
-  BlockSize? get block1Size => _determineBlockSize('block1SZX');
+  BlockSize? get block1Size => _determineBlockSize('block1Size');
 
   // TODO: Consider default method
   /// Indicates the [CoapRequestMethod] contained in this [Form].

--- a/test/binding_coap/coap_vocabulary_test.dart
+++ b/test/binding_coap/coap_vocabulary_test.dart
@@ -34,8 +34,8 @@ void main() {
                 'cov:contentFormat': 60,
                 'cov:accept': 60,
                 'cov:blockwise': {
-                  'cov:block1SZX': 32,
-                  'cov:block2SZX': 64,
+                  'cov:block1Size': 32,
+                  'cov:block2Size': 64,
                 },
                 'response': {
                   'contentType': 'application/cbor',
@@ -45,8 +45,8 @@ void main() {
               {
                 'href': 'coap://example.org',
                 'cov:blockwise': {
-                  'cov:block1SZX': 5000,
-                  'cov:block2SZX': 4096,
+                  'cov:block1Size': 5000,
+                  'cov:block2Size': 4096,
                 },
               },
             ]


### PR DESCRIPTION
This PR incorporates the changes made in https://github.com/w3c/wot-binding-templates/pull/259 into the CoAP binding implementation.