### PR TITLE
refactor: decouple credentials and security scheme classes

### DIFF
--- a/lib/src/core/credentials/ace_credentials.dart
+++ b/lib/src/core/credentials/ace_credentials.dart
@@ -12,7 +12,7 @@ import 'credentials.dart';
 /// [Credentials] used for the [AceSecurityScheme].
 class AceCredentials extends Credentials {
   /// Constructor.
-  AceCredentials(this.accessToken) : super('ace:ACESecurityScheme');
+  AceCredentials(this.accessToken);
 
   /// The access token associated with these [AceCredentials] in serialized
   /// form.

--- a/lib/src/core/credentials/apikey_credentials.dart
+++ b/lib/src/core/credentials/apikey_credentials.dart
@@ -8,10 +8,10 @@ import '../../definitions/security/apikey_security_scheme.dart';
 
 import 'credentials.dart';
 
-/// [Credentials] used for the `APIKeySecurityScheme`.
-class ApiKeyCredentials extends Credentials<ApiKeySecurityScheme> {
+/// [Credentials] used for the [ApiKeySecurityScheme].
+class ApiKeyCredentials extends Credentials {
   /// Constructor.
-  ApiKeyCredentials(this.apiKey) : super('apikey');
+  ApiKeyCredentials(this.apiKey);
 
   /// The [apiKey] associated with these [ApiKeyCredentials].
   String apiKey;

--- a/lib/src/core/credentials/basic_credentials.dart
+++ b/lib/src/core/credentials/basic_credentials.dart
@@ -8,12 +8,12 @@ import '../../definitions/security/basic_security_scheme.dart';
 
 import 'credentials.dart';
 
-/// [Credentials] used for the `BasicSecurityScheme`.
+/// [Credentials] used for the [BasicSecurityScheme].
 ///
 /// Provides an unencrypted [username] and [password] combination.
-class BasicCredentials extends Credentials<BasicSecurityScheme> {
+class BasicCredentials extends Credentials {
   /// Constructor.
-  BasicCredentials(this.username, this.password) : super('basic');
+  BasicCredentials(this.username, this.password);
 
   /// The [username] associated with these [BasicCredentials].
   String username;

--- a/lib/src/core/credentials/bearer_credentials.dart
+++ b/lib/src/core/credentials/bearer_credentials.dart
@@ -8,10 +8,10 @@ import '../../definitions/security/bearer_security_scheme.dart';
 
 import 'credentials.dart';
 
-/// [Credentials] used for the `BearerSecurityScheme`.
-class BearerCredentials extends Credentials<BearerSecurityScheme> {
+/// [Credentials] used for the [BearerSecurityScheme].
+class BearerCredentials extends Credentials {
   /// Constructor.
-  BearerCredentials(this.token) : super('bearer');
+  BearerCredentials(this.token);
 
   /// The [token] associated with these [BearerCredentials].
   String token;

--- a/lib/src/core/credentials/credentials.dart
+++ b/lib/src/core/credentials/credentials.dart
@@ -4,13 +4,5 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../../definitions/security/security_scheme.dart';
-
 /// Base class used for defining credentials for Thing Interactions.
-abstract class Credentials<T extends SecurityScheme> {
-  /// Constructor.
-  Credentials(this.securitySchemeType);
-
-  /// The name of the SecurityScheme these [Credentials] are associated with.
-  final String securitySchemeType;
-}
+abstract class Credentials {}

--- a/lib/src/core/credentials/digest_credentials.dart
+++ b/lib/src/core/credentials/digest_credentials.dart
@@ -8,9 +8,9 @@ import '../../definitions/security/digest_security_scheme.dart';
 import 'credentials.dart';
 
 /// [Credentials] used for the [DigestSecurityScheme].
-class DigestCredentials extends Credentials<DigestSecurityScheme> {
+class DigestCredentials extends Credentials {
   /// Constructor.
-  DigestCredentials(this.username, this.password) : super('digest');
+  DigestCredentials(this.username, this.password);
 
   /// The [username] associated with these [DigestCredentials].
   String username;

--- a/lib/src/core/credentials/oauth2_credentials.dart
+++ b/lib/src/core/credentials/oauth2_credentials.dart
@@ -8,9 +8,9 @@ import '../../definitions/security/oauth2_security_scheme.dart';
 import 'credentials.dart';
 
 /// [Credentials] used for the [OAuth2SecurityScheme].
-class OAuth2Credentials extends Credentials<OAuth2SecurityScheme> {
+class OAuth2Credentials extends Credentials {
   /// Constructor.
-  OAuth2Credentials([this.secret]) : super('oauth2');
+  OAuth2Credentials([this.secret]);
 
   /// The optional secret for these [OAuth2Credentials].
   String? secret;

--- a/lib/src/core/credentials/psk_credentials.dart
+++ b/lib/src/core/credentials/psk_credentials.dart
@@ -10,10 +10,9 @@ import '../../definitions/security/psk_security_scheme.dart';
 import 'credentials.dart';
 
 /// [Credentials] used for the [PskSecurityScheme].
-class PskCredentials extends Credentials<PskSecurityScheme> {
+class PskCredentials extends Credentials {
   /// Constructor.
-  PskCredentials({required this.preSharedKey, required this.identity})
-      : super('psk');
+  PskCredentials({required this.preSharedKey, required this.identity});
 
   /// The [identity] associated with these [PskCredentials].
   ///


### PR DESCRIPTION
I noticed that the `SecurityScheme` and the respective `Credentials` classes actually do not need to be coupled as tightly as they are at the moment. Therefore, this PR decouples them.