### PR TITLE
feat!(security_scheme): use `Uri` instead of `String` for proxy field

### DIFF
--- a/lib/src/definitions/security/psk_security_scheme.dart
+++ b/lib/src/definitions/security/psk_security_scheme.dart
@@ -16,7 +16,7 @@ class PskSecurityScheme extends SecurityScheme {
   PskSecurityScheme({
     this.identity,
     String? description,
-    String? proxy,
+    Uri? proxy,
     Map<String, String>? descriptions,
   }) : super('psk') {
     this.description = description;

--- a/lib/src/definitions/security/security_scheme.dart
+++ b/lib/src/definitions/security/security_scheme.dart
@@ -42,7 +42,10 @@ abstract class SecurityScheme {
   /// A [Map] of multi-language [descriptions].
   Map<String, String> descriptions = {};
 
+  /// [Uri] of the proxy server this security configuration provides access to.
   ///
+  /// If not given, the corresponding security configuration is for the
+  /// endpoint.
   Uri? proxy;
 
   /// A [List] of JSON-LD `@type` annotations.

--- a/lib/src/definitions/security/security_scheme.dart
+++ b/lib/src/definitions/security/security_scheme.dart
@@ -43,7 +43,7 @@ abstract class SecurityScheme {
   Map<String, String> descriptions = {};
 
   ///
-  String? proxy;
+  Uri? proxy;
 
   /// A [List] of JSON-LD `@type` annotations.
   List<String>? jsonLdType = [];
@@ -59,7 +59,7 @@ abstract class SecurityScheme {
   ) {
     parsedFields.add('scheme');
 
-    proxy = json.parseField<String>('proxy', parsedFields);
+    proxy = json.parseUriField('proxy', parsedFields);
     description = json.parseField<String>('description', parsedFields);
     descriptions
         .addAll(json.parseMapField<String>('descriptions', parsedFields) ?? {});

--- a/test/core/consumed_thing_test.dart
+++ b/test/core/consumed_thing_test.dart
@@ -166,7 +166,7 @@ void main() {
 
       final nosecSc = parsedTd.securityDefinitions['nosec_sc'];
       expect(nosecSc is NoSecurityScheme, true);
-      expect(nosecSc?.proxy, 'http://example.org');
+      expect(nosecSc?.proxy, Uri.parse('http://example.org'));
       expect(nosecSc?.jsonLdType, ['Test']);
 
       final basicSc = parsedTd.securityDefinitions['basic_sc'];


### PR DESCRIPTION
This PR changes the `proxy` field in the `SecurityScheme` class to use the more appropriate `Uri` type and adds missing documentation.