### PR TITLE
feat: add ComboSecurityScheme

### DIFF
--- a/lib/src/definitions/security/combo_security_scheme.dart
+++ b/lib/src/definitions/security/combo_security_scheme.dart
@@ -1,0 +1,46 @@
+// Copyright 2023 The NAMIB Project Developers. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+import 'package:curie/curie.dart';
+
+import '../extensions/json_parser.dart';
+import 'security_scheme.dart';
+
+const _schemeName = 'combo';
+
+/// A combination of other security schemes identified by the Vocabulary Term
+/// `combo` (i.e., "scheme": "combo").
+class ComboSecurityScheme extends SecurityScheme {
+  /// Constructor.
+  ComboSecurityScheme({
+    this.allOf,
+    this.oneOf,
+    super.description,
+    super.descriptions,
+    super.proxy,
+  }) : super(_schemeName);
+
+  /// Creates a [ComboSecurityScheme] from a [json] object.
+  ComboSecurityScheme.fromJson(
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping,
+    Set<String> parsedFields,
+  )   : oneOf = json.parseArrayField<String>('oneOf', parsedFields),
+        allOf = json.parseArrayField<String>('allOf', parsedFields),
+        super(_schemeName) {
+    parseSecurityJson(json, parsedFields, prefixMapping);
+  }
+
+  /// Array of two or more strings identifying other named security scheme
+  /// definitions, any one of which, when satisfied, will allow access.
+  ///
+  /// Only one may be chosen for use.
+  final List<String>? oneOf;
+
+  /// Array of two or more strings identifying other named security scheme
+  /// definitions, all of which must be satisfied for access.
+  final List<String>? allOf;
+}

--- a/lib/src/definitions/security/security_scheme.dart
+++ b/lib/src/definitions/security/security_scheme.dart
@@ -12,6 +12,7 @@ import 'apikey_security_scheme.dart';
 import 'auto_security_scheme.dart';
 import 'basic_security_scheme.dart';
 import 'bearer_security_scheme.dart';
+import 'combo_security_scheme.dart';
 import 'digest_security_scheme.dart';
 import 'no_security_scheme.dart';
 import 'oauth2_security_scheme.dart';
@@ -84,6 +85,8 @@ abstract class SecurityScheme {
         return BasicSecurityScheme.fromJson(json, prefixMapping);
       case 'bearer':
         return BearerSecurityScheme.fromJson(json, prefixMapping);
+      case 'combo':
+        return ComboSecurityScheme.fromJson(json, prefixMapping, {});
       case 'nosec':
         return NoSecurityScheme.fromJson(json, prefixMapping);
       case 'psk':

--- a/test/core/consumed_thing_test.dart
+++ b/test/core/consumed_thing_test.dart
@@ -8,6 +8,7 @@ import 'package:dart_wot/dart_wot.dart';
 import 'package:dart_wot/src/definitions/security/apikey_security_scheme.dart';
 import 'package:dart_wot/src/definitions/security/basic_security_scheme.dart';
 import 'package:dart_wot/src/definitions/security/bearer_security_scheme.dart';
+import 'package:dart_wot/src/definitions/security/combo_security_scheme.dart';
 import 'package:dart_wot/src/definitions/security/digest_security_scheme.dart';
 import 'package:dart_wot/src/definitions/security/no_security_scheme.dart';
 import 'package:dart_wot/src/definitions/security/oauth2_security_scheme.dart';
@@ -79,6 +80,14 @@ void main() {
             "refresh": "http://example.org",
             "scopes": "test",
             "flow": "client"
+          },
+          "combo_sc1": {
+            "scheme": "combo",
+            "allOf": ["digest_sc", "apikey_sc"]
+          },
+          "combo_sc2": {
+            "scheme": "combo",
+            "oneOf": ["oauth2_sc", "bearer_sc"]
           }
         },
         "security": "nosec_sc",
@@ -210,6 +219,22 @@ void main() {
       expect(oauth2Sc.token, 'http://example.org');
       expect(oauth2Sc.scopes, ['test']);
       expect(oauth2Sc.flow, 'client');
+
+      final comboSc1 = parsedTd.securityDefinitions['combo_sc1'];
+      expect(comboSc1 is ComboSecurityScheme, true);
+      expect(
+        (comboSc1 as ComboSecurityScheme?)!.allOf,
+        ['digest_sc', 'apikey_sc'],
+      );
+      expect(comboSc1!.oneOf, null);
+
+      final comboSc2 = parsedTd.securityDefinitions['combo_sc2'];
+      expect(comboSc2 is ComboSecurityScheme, true);
+      expect(
+        (comboSc2 as ComboSecurityScheme?)!.oneOf,
+        ['oauth2_sc', 'bearer_sc'],
+      );
+      expect(comboSc2!.allOf, null);
     });
   });
 


### PR DESCRIPTION
This PR adds the currently missing `ComboSecurityScheme` as a new feature. The implementation will be slightly adjusted in the context of #44.