### PR TITLE
refactor!: rework deserialization of security schemes

### DIFF
--- a/lib/src/definitions/extensions/json_parser.dart
+++ b/lib/src/definitions/extensions/json_parser.dart
@@ -9,6 +9,16 @@ import '../interaction_affordances/event.dart';
 import '../interaction_affordances/interaction_affordance.dart';
 import '../interaction_affordances/property.dart';
 import '../link.dart';
+import '../security/ace_security_scheme.dart';
+import '../security/apikey_security_scheme.dart';
+import '../security/auto_security_scheme.dart';
+import '../security/basic_security_scheme.dart';
+import '../security/bearer_security_scheme.dart';
+import '../security/combo_security_scheme.dart';
+import '../security/digest_security_scheme.dart';
+import '../security/no_security_scheme.dart';
+import '../security/oauth2_security_scheme.dart';
+import '../security/psk_security_scheme.dart';
 import '../security/security_scheme.dart';
 import '../thing_description.dart';
 import '../validation/validation_exception.dart';
@@ -312,7 +322,7 @@ extension ParseField on Map<String, dynamic> {
   /// defined.
   Map<String, SecurityScheme>? parseSecurityDefinitions(
     PrefixMapping prefixMapping,
-    Set<String>? parsedFields,
+    Set<String> parsedFields,
   ) {
     final fieldValue =
         parseMapField<dynamic>('securityDefinitions', parsedFields);
@@ -326,7 +336,7 @@ extension ParseField on Map<String, dynamic> {
     for (final securityDefinition in fieldValue.entries) {
       final dynamic value = securityDefinition.value;
       if (value is Map<String, dynamic>) {
-        final securityScheme = SecurityScheme.fromJson(value, prefixMapping);
+        final securityScheme = value._parseSecurityScheme(prefixMapping, {});
         if (securityScheme != null) {
           result[securityDefinition.key] = securityScheme;
         }
@@ -334,6 +344,38 @@ extension ParseField on Map<String, dynamic> {
     }
 
     return result;
+  }
+
+  SecurityScheme? _parseSecurityScheme(
+    PrefixMapping prefixMapping,
+    Set<String> parsedFields,
+  ) {
+    final scheme = parseRequiredField('scheme', parsedFields);
+
+    switch (scheme) {
+      case 'auto':
+        return AutoSecurityScheme.fromJson(this, prefixMapping, parsedFields);
+      case 'basic':
+        return BasicSecurityScheme.fromJson(this, prefixMapping, parsedFields);
+      case 'bearer':
+        return BearerSecurityScheme.fromJson(this, prefixMapping, parsedFields);
+      case 'combo':
+        return ComboSecurityScheme.fromJson(this, prefixMapping, parsedFields);
+      case 'nosec':
+        return NoSecurityScheme.fromJson(this, prefixMapping, parsedFields);
+      case 'psk':
+        return PskSecurityScheme.fromJson(this, prefixMapping, parsedFields);
+      case 'digest':
+        return DigestSecurityScheme.fromJson(this, prefixMapping, parsedFields);
+      case 'apikey':
+        return ApiKeySecurityScheme.fromJson(this, prefixMapping, parsedFields);
+      case 'oauth2':
+        return OAuth2SecurityScheme.fromJson(this, prefixMapping, parsedFields);
+      case 'ace:ACESecurityScheme':
+        return AceSecurityScheme.fromJson(this, prefixMapping, parsedFields);
+    }
+
+    return null;
   }
 
   /// Parses [Property]s contained in this JSON object.

--- a/lib/src/definitions/security/ace_security_scheme.dart
+++ b/lib/src/definitions/security/ace_security_scheme.dart
@@ -10,41 +10,44 @@ import '../extensions/json_parser.dart';
 
 import 'security_scheme.dart';
 
+const _schemeName = 'ace:ACESecurityScheme';
+
 /// Experimental ACE Security Scheme.
 class AceSecurityScheme extends SecurityScheme {
   /// Constructor.
   AceSecurityScheme({
-    String? description,
     this.as,
     this.audience,
     this.scopes,
     this.cnonce,
-    Map<String, String>? descriptions,
-  }) : super('ace:ACESecurityScheme') {
-    this.description = description;
-    this.descriptions.addAll(descriptions ?? {});
-  }
+    super.description,
+    super.descriptions,
+    super.proxy,
+    super.jsonLdType,
+    super.additionalFields,
+  }) : super(_schemeName);
 
   /// Creates an [AceSecurityScheme] from a [json] object.
   AceSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) : super('ace:ACESecurityScheme') {
-    final Set<String> parsedFields = {};
-
-    as = json.parseField<String>('ace:as', parsedFields);
-    cnonce = json.parseField<bool>('ace:cnonce', parsedFields);
-    audience = json.parseField<String>('ace:audience', parsedFields);
-    scopes = json.parseArrayField<String>('ace:scopes', parsedFields);
-
-    parseSecurityJson(json, parsedFields, prefixMapping);
-  }
+    Set<String> parsedFields,
+  )   : as = json.parseField<String>('ace:as', parsedFields),
+        cnonce = json.parseField<bool>('ace:cnonce', parsedFields),
+        audience = json.parseField<String>('ace:audience', parsedFields),
+        scopes = json.parseArrayField<String>('ace:scopes', parsedFields),
+        super.fromJson(
+          _schemeName,
+          json,
+          prefixMapping,
+          parsedFields,
+        );
 
   /// URI of the authorization server.
-  String? as;
+  final String? as;
 
   /// The intended audience for this [AceSecurityScheme].
-  String? audience;
+  final String? audience;
 
   /// Set of authorization scope identifiers provided as an array.
   ///
@@ -52,8 +55,8 @@ class AceSecurityScheme extends SecurityScheme {
   /// associated with forms in order to identify what resources a client may
   /// access and how. The values associated with a form should be chosen from
   /// those defined in an [AceSecurityScheme] active on that form.
-  List<String>? scopes;
+  final List<String>? scopes;
 
   /// Indicates whether a [cnonce] is required by the Resource Server.
-  bool? cnonce;
+  final bool? cnonce;
 }

--- a/lib/src/definitions/security/apikey_security_scheme.dart
+++ b/lib/src/definitions/security/apikey_security_scheme.dart
@@ -10,36 +10,40 @@ import '../extensions/json_parser.dart';
 import 'security_scheme.dart';
 
 const _defaultInValue = 'query';
+const _schemeName = 'apikey';
 
 /// API key authentication security configuration identified by the Vocabulary
 /// Term `apikey`.
 class ApiKeySecurityScheme extends SecurityScheme {
   /// Constructor.
   ApiKeySecurityScheme({
-    super.description,
-    super.proxy,
     this.name,
-    String? in_,
+    this.in_ = _defaultInValue,
+    super.description,
     super.descriptions,
-  })  : in_ = in_ ?? _defaultInValue,
-        super('apikey');
+    super.proxy,
+    super.jsonLdType,
+    super.additionalFields,
+  }) : super(_schemeName);
 
   /// Creates a [ApiKeySecurityScheme] from a [json] object.
+
   ApiKeySecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) : super('apikey') {
-    final Set<String> parsedFields = {};
-
-    name = json.parseField<String>('name', parsedFields);
-    in_ = json.parseField<String>('in', parsedFields) ?? _defaultInValue;
-
-    parseSecurityJson(json, parsedFields, prefixMapping);
-  }
+    Set<String> parsedFields,
+  )   : name = json.parseField<String>('name', parsedFields),
+        in_ = json.parseField<String>('in', parsedFields) ?? _defaultInValue,
+        super.fromJson(
+          _schemeName,
+          json,
+          prefixMapping,
+          parsedFields,
+        );
 
   /// Name for query, header, cookie, or uri parameters.
   String? name;
 
   /// Specifies the location of security authentication information.
-  late String in_;
+  final String in_;
 }

--- a/lib/src/definitions/security/auto_security_scheme.dart
+++ b/lib/src/definitions/security/auto_security_scheme.dart
@@ -8,14 +8,24 @@ import 'package:curie/curie.dart';
 
 import 'security_scheme.dart';
 
+const _schemeName = 'auto';
+
 /// An automatic security configuration identified by the
 /// vocabulary term `auto`.
 class AutoSecurityScheme extends SecurityScheme {
+  /// Constructor.
+  AutoSecurityScheme({
+    super.description,
+    super.descriptions,
+    super.proxy,
+    super.jsonLdType,
+    super.additionalFields,
+  }) : super(_schemeName);
+
   /// Creates an [AutoSecurityScheme] from a [json] object.
   AutoSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) : super('auto') {
-    parseSecurityJson(json, {}, prefixMapping);
-  }
+    Set<String> parsedFields,
+  ) : super.fromJson(_schemeName, json, prefixMapping, parsedFields);
 }

--- a/lib/src/definitions/security/basic_security_scheme.dart
+++ b/lib/src/definitions/security/basic_security_scheme.dart
@@ -11,35 +11,34 @@ import 'security_scheme.dart';
 
 const _defaultInValue = 'header';
 
+const _schemeName = 'basic';
+
 /// Basic Authentication security configuration identified by the Vocabulary
 /// Term `basic`.
 class BasicSecurityScheme extends SecurityScheme {
   /// Constructor.
   BasicSecurityScheme({
-    super.description,
-    super.proxy,
     this.name,
-    String? in_,
+    this.in_ = _defaultInValue,
+    super.description,
     super.descriptions,
-  })  : in_ = in_ ?? _defaultInValue,
-        super('basic');
+    super.proxy,
+    super.jsonLdType,
+    super.additionalFields,
+  }) : super(_schemeName);
 
   /// Creates a [BasicSecurityScheme] from a [json] object.
   BasicSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) : super('basic') {
-    final Set<String> parsedFields = {};
-
-    name = json.parseField<String>('name', parsedFields);
-    in_ = json.parseField<String>('in', parsedFields) ?? _defaultInValue;
-
-    parseSecurityJson(json, parsedFields, prefixMapping);
-  }
+    Set<String> parsedFields,
+  )   : name = json.parseField<String>('name', parsedFields),
+        in_ = json.parseField<String>('in', parsedFields) ?? _defaultInValue,
+        super.fromJson(_schemeName, json, prefixMapping, parsedFields);
 
   /// Name for query, header, cookie, or uri parameters.
-  late final String? name;
+  final String? name;
 
   /// Specifies the location of security authentication information.
-  late String in_ = 'header';
+  final String in_;
 }

--- a/lib/src/definitions/security/bearer_security_scheme.dart
+++ b/lib/src/definitions/security/bearer_security_scheme.dart
@@ -13,53 +13,50 @@ const _defaultInValue = 'header';
 const _defaultAlgValue = 'ES256';
 const _defaultFormatValue = 'jwt';
 
+const _schemeName = 'bearer';
+
 /// Bearer Token security configuration identified by the Vocabulary Term
 /// `bearer`.
 class BearerSecurityScheme extends SecurityScheme {
   /// Constructor.
   BearerSecurityScheme({
     this.name,
-    String? alg,
-    String? format,
+    this.alg = _defaultAlgValue,
+    this.format = _defaultFormatValue,
     this.authorization,
-    String? in_,
-    super.proxy,
+    this.in_ = _defaultInValue,
     super.description,
     super.descriptions,
-  })  : in_ = in_ ?? _defaultInValue,
-        alg = alg ?? _defaultAlgValue,
-        format = format ?? _defaultFormatValue,
-        super('bearer');
+    super.proxy,
+    super.jsonLdType,
+    super.additionalFields,
+  }) : super(_schemeName);
 
   /// Creates a [BearerSecurityScheme] from a [json] object.
   BearerSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) : super('bearer') {
-    final Set<String> parsedFields = {};
-
-    name = json.parseField<String>('name', parsedFields);
-    in_ = json.parseField<String>('in', parsedFields) ?? _defaultInValue;
-    format =
-        json.parseField<String>('format', parsedFields) ?? _defaultFormatValue;
-    alg = json.parseField<String>('alg', parsedFields) ?? _defaultAlgValue;
-    authorization = json.parseField<String>('authorization', parsedFields);
-
-    parseSecurityJson(json, parsedFields, prefixMapping);
-  }
+    Set<String> parsedFields,
+  )   : name = json.parseField<String>('name', parsedFields),
+        in_ = json.parseField<String>('in', parsedFields) ?? _defaultInValue,
+        format = json.parseField<String>('format', parsedFields) ??
+            _defaultFormatValue,
+        alg = json.parseField<String>('alg', parsedFields) ?? _defaultAlgValue,
+        authorization = json.parseField<String>('authorization', parsedFields),
+        super.fromJson(_schemeName, json, prefixMapping, parsedFields);
 
   /// URI of the authorization server.
-  late final String? authorization;
+  final String? authorization;
 
   /// Name for query, header, cookie, or uri parameters.
-  late final String? name;
+  final String? name;
 
   /// Encoding, encryption, or digest algorithm.
-  late final String alg;
+  final String alg;
 
   /// Specifies format of security authentication information.
-  late final String format;
+  final String format;
 
   /// Specifies the location of security authentication information.
-  late final String in_;
+  final String in_;
 }

--- a/lib/src/definitions/security/combo_security_scheme.dart
+++ b/lib/src/definitions/security/combo_security_scheme.dart
@@ -21,6 +21,8 @@ class ComboSecurityScheme extends SecurityScheme {
     super.description,
     super.descriptions,
     super.proxy,
+    super.jsonLdType,
+    super.additionalFields,
   }) : super(_schemeName);
 
   /// Creates a [ComboSecurityScheme] from a [json] object.
@@ -30,9 +32,7 @@ class ComboSecurityScheme extends SecurityScheme {
     Set<String> parsedFields,
   )   : oneOf = json.parseArrayField<String>('oneOf', parsedFields),
         allOf = json.parseArrayField<String>('allOf', parsedFields),
-        super(_schemeName) {
-    parseSecurityJson(json, parsedFields, prefixMapping);
-  }
+        super.fromJson(_schemeName, json, prefixMapping, parsedFields);
 
   /// Array of two or more strings identifying other named security scheme
   /// definitions, any one of which, when satisfied, will allow access.

--- a/lib/src/definitions/security/digest_security_scheme.dart
+++ b/lib/src/definitions/security/digest_security_scheme.dart
@@ -18,36 +18,32 @@ const _defaultQoPValue = 'auth';
 class DigestSecurityScheme extends SecurityScheme {
   /// Constructor.
   DigestSecurityScheme({
-    String? in_,
-    String? qop,
-    super.description,
-    super.proxy,
+    this.in_ = _defaultInValue,
+    this.qop = _defaultQoPValue,
     this.name,
+    super.description,
     super.descriptions,
-  })  : in_ = in_ ?? _defaultInValue,
-        qop = qop ?? _defaultQoPValue,
-        super('digest');
+    super.proxy,
+    super.jsonLdType,
+    super.additionalFields,
+  }) : super('digest');
 
   /// Creates a [DigestSecurityScheme] from a [json] object.
   DigestSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) : super('digest') {
-    final Set<String> parsedFields = {};
-
-    name = json.parseField<String>('name', parsedFields);
-    in_ = json.parseField<String>('in', parsedFields) ?? _defaultInValue;
-    qop = json.parseField<String>('qop', parsedFields) ?? _defaultInValue;
-
-    parseSecurityJson(json, parsedFields, prefixMapping);
-  }
+    Set<String> parsedFields,
+  )   : name = json.parseField<String>('name', parsedFields),
+        in_ = json.parseField<String>('in', parsedFields) ?? _defaultInValue,
+        qop = json.parseField<String>('qop', parsedFields) ?? _defaultInValue,
+        super.fromJson('digest', json, prefixMapping, parsedFields);
 
   /// Name for query, header, cookie, or uri parameters.
-  late final String? name;
+  final String? name;
 
   /// Specifies the location of security authentication information.
-  late final String in_;
+  final String in_;
 
   /// Quality of protection.
-  late final String? qop;
+  final String qop;
 }

--- a/lib/src/definitions/security/no_security_scheme.dart
+++ b/lib/src/definitions/security/no_security_scheme.dart
@@ -8,14 +8,24 @@ import 'package:curie/curie.dart';
 
 import 'security_scheme.dart';
 
+const _schemeName = 'nosec';
+
 /// A security configuration corresponding to identified by the Vocabulary Term
 /// `nosec`.
 class NoSecurityScheme extends SecurityScheme {
+  /// Constructor.
+  NoSecurityScheme({
+    super.description,
+    super.descriptions,
+    super.proxy,
+    super.jsonLdType,
+    super.additionalFields,
+  }) : super(_schemeName);
+
   /// Creates a [NoSecurityScheme] from a [json] object.
   NoSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) : super('nosec') {
-    parseSecurityJson(json, {}, prefixMapping);
-  }
+    Set<String> parsedFields,
+  ) : super.fromJson(_schemeName, json, prefixMapping, parsedFields);
 }

--- a/lib/src/definitions/security/oauth2_security_scheme.dart
+++ b/lib/src/definitions/security/oauth2_security_scheme.dart
@@ -9,6 +9,8 @@ import 'package:curie/curie.dart';
 import '../extensions/json_parser.dart';
 import 'security_scheme.dart';
 
+const _schemeName = 'oauth2';
+
 /// OAuth 2.0 authentication security configuration for systems conformant with
 /// RFC 6749, RFC 8252 and (for the device flow) RFC 8628, identified by the
 /// Vocabulary Term `oauth2`.
@@ -16,44 +18,40 @@ class OAuth2SecurityScheme extends SecurityScheme {
   /// Constructor.
   OAuth2SecurityScheme(
     this.flow, {
-    String? description,
     this.authorization,
     this.scopes,
     this.refresh,
     this.token,
-    Map<String, String>? descriptions,
-  }) : super('oauth2') {
-    this.description = description;
-    this.descriptions.addAll(descriptions ?? {});
-  }
+    super.description,
+    super.descriptions,
+    super.proxy,
+    super.jsonLdType,
+    super.additionalFields,
+  }) : super(_schemeName);
 
   /// Creates a [OAuth2SecurityScheme] from a [json] object.
   OAuth2SecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) : super('oauth2') {
-    final Set<String> parsedFields = {};
-
-    authorization = json.parseField<String>('authorization', parsedFields);
-    token = json.parseField<String>('token', parsedFields);
-    refresh = json.parseField<String>('refresh', parsedFields);
-    scopes = json.parseArrayField<String>('scopes', parsedFields);
-    flow = json.parseRequiredField<String>('flow', parsedFields);
-
-    parseSecurityJson(json, parsedFields, prefixMapping);
-  }
+    Set<String> parsedFields,
+  )   : authorization = json.parseField<String>('authorization', parsedFields),
+        token = json.parseField<String>('token', parsedFields),
+        refresh = json.parseField<String>('refresh', parsedFields),
+        scopes = json.parseArrayField<String>('scopes', parsedFields),
+        flow = json.parseRequiredField<String>('flow', parsedFields),
+        super.fromJson(_schemeName, json, prefixMapping, parsedFields);
 
   /// URI of the authorization server.
   ///
   /// In the case of the `device` flow, the URI provided for the [authorization]
   /// value refers to the device authorization endpoint.
-  late String? authorization;
+  final String? authorization;
 
   /// URI of the token server.
-  late String? token;
+  final String? token;
 
   /// URI of the authorization server.
-  late String? refresh;
+  final String? refresh;
 
   /// Set of authorization scope identifiers provided as an array.
   ///
@@ -61,8 +59,8 @@ class OAuth2SecurityScheme extends SecurityScheme {
   /// associated with forms in order to identify what resources a client may
   /// access and how. The values associated with a form should be chosen from
   /// those defined in an [OAuth2SecurityScheme] active on that form.
-  late List<String>? scopes;
+  final List<String>? scopes;
 
   /// Authorization flow.
-  late String flow;
+  final String flow;
 }

--- a/lib/src/definitions/security/psk_security_scheme.dart
+++ b/lib/src/definitions/security/psk_security_scheme.dart
@@ -9,33 +9,29 @@ import 'package:curie/curie.dart';
 import '../extensions/json_parser.dart';
 import 'security_scheme.dart';
 
+const _schemeName = 'psk';
+
 /// Pre-shared key authentication security configuration identified by the
 /// Vocabulary Term `psk`.
 class PskSecurityScheme extends SecurityScheme {
   /// Constructor.
   PskSecurityScheme({
     this.identity,
-    String? description,
-    Uri? proxy,
-    Map<String, String>? descriptions,
-  }) : super('psk') {
-    this.description = description;
-    this.proxy = proxy;
-    this.descriptions.addAll(descriptions ?? {});
-  }
+    super.description,
+    super.descriptions,
+    super.proxy,
+    super.jsonLdType,
+    super.additionalFields,
+  }) : super(_schemeName);
 
   /// Creates a [PskSecurityScheme] from a [json] object.
   PskSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-  ) : super('psk') {
-    final Set<String> parsedFields = {};
-
-    identity = json.parseField<String>('identity');
-
-    parseSecurityJson(json, parsedFields, prefixMapping);
-  }
+    Set<String> parsedFields,
+  )   : identity = json.parseField<String>('identity'),
+        super.fromJson(_schemeName, json, prefixMapping, parsedFields);
 
   /// Name for query, header, cookie, or uri parameters.
-  String? identity;
+  final String? identity;
 }

--- a/lib/src/definitions/security/security_scheme.dart
+++ b/lib/src/definitions/security/security_scheme.dart
@@ -7,16 +7,6 @@
 import 'package:curie/curie.dart';
 
 import '../extensions/json_parser.dart';
-import 'ace_security_scheme.dart';
-import 'apikey_security_scheme.dart';
-import 'auto_security_scheme.dart';
-import 'basic_security_scheme.dart';
-import 'bearer_security_scheme.dart';
-import 'combo_security_scheme.dart';
-import 'digest_security_scheme.dart';
-import 'no_security_scheme.dart';
-import 'oauth2_security_scheme.dart';
-import 'psk_security_scheme.dart';
 
 /// Class that contains metadata describing the configuration of a security
 /// mechanism.
@@ -24,12 +14,25 @@ abstract class SecurityScheme {
   /// Constructor.
   SecurityScheme(
     this.scheme, {
+    this.jsonLdType,
     this.description,
     this.proxy,
-    Map<String, String>? descriptions,
-  }) {
-    this.descriptions.addAll(descriptions ?? {});
-  }
+    this.descriptions,
+    this.additionalFields,
+  });
+
+  /// Creates a [SecurityScheme] from a [json] object.
+  SecurityScheme.fromJson(
+    this.scheme,
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping,
+    Set<String> parsedFields,
+  )   : proxy = json.parseUriField('proxy', parsedFields),
+        description = json.parseField<String>('description', parsedFields),
+        descriptions = json.parseMapField<String>('descriptions', parsedFields),
+        jsonLdType = json.parseArrayField<String>('@type'),
+        additionalFields =
+            json.parseAdditionalFields(prefixMapping, parsedFields);
 
   /// The actual security [scheme] identifier.
   ///
@@ -38,69 +41,20 @@ abstract class SecurityScheme {
   final String scheme;
 
   /// The default [description] of this [SecurityScheme].
-  String? description;
+  final String? description;
 
   /// A [Map] of multi-language [descriptions].
-  Map<String, String> descriptions = {};
+  final Map<String, String>? descriptions;
 
   /// [Uri] of the proxy server this security configuration provides access to.
   ///
   /// If not given, the corresponding security configuration is for the
   /// endpoint.
-  Uri? proxy;
+  final Uri? proxy;
 
   /// A [List] of JSON-LD `@type` annotations.
-  List<String>? jsonLdType = [];
+  final List<String>? jsonLdType;
 
   /// Additional fields collected during the parsing of a JSON object.
-  final Map<String, dynamic> additionalFields = <String, dynamic>{};
-
-  /// Parses the fields shared by all [SecurityScheme]s.
-  void parseSecurityJson(
-    Map<String, dynamic> json,
-    Set<String> parsedFields,
-    PrefixMapping prefixMapping,
-  ) {
-    parsedFields.add('scheme');
-
-    proxy = json.parseUriField('proxy', parsedFields);
-    description = json.parseField<String>('description', parsedFields);
-    descriptions
-        .addAll(json.parseMapField<String>('descriptions', parsedFields) ?? {});
-    jsonLdType = json.parseArrayField<String>('@type');
-
-    additionalFields
-        .addAll(json.parseAdditionalFields(prefixMapping, parsedFields));
-  }
-
-  /// Creates a [SecurityScheme] from a [json] object.
-  static SecurityScheme? fromJson(
-    Map<String, dynamic> json,
-    PrefixMapping prefixMapping,
-  ) {
-    switch (json['scheme']) {
-      case 'auto':
-        return AutoSecurityScheme.fromJson(json, prefixMapping);
-      case 'basic':
-        return BasicSecurityScheme.fromJson(json, prefixMapping);
-      case 'bearer':
-        return BearerSecurityScheme.fromJson(json, prefixMapping);
-      case 'combo':
-        return ComboSecurityScheme.fromJson(json, prefixMapping, {});
-      case 'nosec':
-        return NoSecurityScheme.fromJson(json, prefixMapping);
-      case 'psk':
-        return PskSecurityScheme.fromJson(json, prefixMapping);
-      case 'digest':
-        return DigestSecurityScheme.fromJson(json, prefixMapping);
-      case 'apikey':
-        return ApiKeySecurityScheme.fromJson(json, prefixMapping);
-      case 'oauth2':
-        return OAuth2SecurityScheme.fromJson(json, prefixMapping);
-      case 'ace:ACESecurityScheme':
-        return AceSecurityScheme.fromJson(json, prefixMapping);
-    }
-
-    return null;
-  }
+  final Map<String, dynamic>? additionalFields;
 }


### PR DESCRIPTION
This PR refactors the deserialization of the different `SecurityScheme` sub-classes, making the implementation more null-safe.