### PR TITLE
style: use const constructor in complex_example

### DIFF
--- a/example/complex_example.dart
+++ b/example/complex_example.dart
@@ -135,7 +135,7 @@ Future<void> main() async {
 
   final status3 = await consumedThing.readProperty(
     'anotherStatus',
-    InteractionOptions(uriVariables: {'test': 'hi'}),
+    const InteractionOptions(uriVariables: {'test': 'hi'}),
   );
   final value3 = await status3.value();
   print(value3);


### PR DESCRIPTION
This PR addresses a (relatively trivial) linting issue.