### PR TITLE
Improve `Content` APIs

### DIFF
--- a/lib/src/binding_coap/coap_client.dart
+++ b/lib/src/binding_coap/coap_client.dart
@@ -97,7 +97,7 @@ final class CoapClient implements ProtocolClient {
     coap.BlockSize? block1Size,
     coap.BlockSize? block2Size,
   }) async {
-    final payload = (await content?.byteBuffer)?.asUint8List();
+    final payload = await content?.toByteList();
 
     final request = coap.CoapRequest(
       uri,

--- a/lib/src/binding_http/http_client.dart
+++ b/lib/src/binding_http/http_client.dart
@@ -245,9 +245,9 @@ final class HttpClient implements ProtocolClient {
   }
 
   Future<String> _getInputFromContent(Content content) async {
-    final inputBuffer = await content.byteBuffer;
-    return utf8.decoder
-        .convert(inputBuffer.asUint8List().toList(growable: false));
+    final inputBuffer =
+        await content.body.expand((element) => element).toList();
+    return utf8.decoder.convert(inputBuffer);
   }
 
   Content _contentFromResponse(Form form, StreamedResponse response) {

--- a/lib/src/binding_http/http_client.dart
+++ b/lib/src/binding_http/http_client.dart
@@ -188,18 +188,15 @@ final class HttpClient implements ProtocolClient {
   Future<StreamedResponse> _createRequest(
     Form form,
     OperationType operationType,
-    String? payload,
+    Content? content,
   ) async {
     final requestMethod =
         HttpRequestMethod.getRequestMethod(form, operationType);
     final Uri uri = form.resolvedHref;
 
     final request = Request(requestMethod.methodName, uri)
-      ..headers.addAll(_getHeadersFromForm(form));
-
-    if (payload != null) {
-      request.body = payload;
-    }
+      ..headers.addAll(_getHeadersFromForm(form))
+      ..bodyBytes = await content?.toByteList() ?? [];
 
     await _applyCredentialsFromForm(request, form);
 
@@ -244,12 +241,6 @@ final class HttpClient implements ProtocolClient {
     return headers;
   }
 
-  Future<String> _getInputFromContent(Content content) async {
-    final inputBuffer =
-        await content.body.expand((element) => element).toList();
-    return utf8.decoder.convert(inputBuffer);
-  }
-
   Content _contentFromResponse(Form form, StreamedResponse response) {
     final type = response.headers['Content-Type'] ?? form.contentType;
     final responseStream = response.stream.asBroadcastStream()
@@ -259,9 +250,8 @@ final class HttpClient implements ProtocolClient {
 
   @override
   Future<Content> invokeResource(Form form, Content content) async {
-    final input = await _getInputFromContent(content);
     final response =
-        await _createRequest(form, OperationType.invokeaction, input);
+        await _createRequest(form, OperationType.invokeaction, content);
     return _contentFromResponse(form, response);
   }
 
@@ -284,8 +274,7 @@ final class HttpClient implements ProtocolClient {
 
   @override
   Future<void> writeResource(Form form, Content content) async {
-    final input = await _getInputFromContent(content);
-    await _createRequest(form, OperationType.writeproperty, input);
+    await _createRequest(form, OperationType.writeproperty, content);
   }
 
   @override

--- a/lib/src/binding_mqtt/mqtt_client.dart
+++ b/lib/src/binding_mqtt/mqtt_client.dart
@@ -107,7 +107,7 @@ final class MqttClient implements ProtocolClient {
       ..publishMessage(
         topic,
         qualityOfService,
-        Uint8Buffer()..addAll((await content.byteBuffer).asUint8List()),
+        Uint8Buffer()..addAll(await content.toByteList()),
         retain: form.retain ?? false,
       )
       ..disconnect();
@@ -162,7 +162,7 @@ final class MqttClient implements ProtocolClient {
       ..publishMessage(
         topic,
         qualityOfService,
-        Uint8Buffer()..addAll((await content.byteBuffer).asUint8List()),
+        Uint8Buffer()..addAll(await content.toByteList()),
         retain: form.retain ?? false,
       )
       ..disconnect();

--- a/lib/src/core/codecs/cbor_codec.dart
+++ b/lib/src/core/codecs/cbor_codec.dart
@@ -4,8 +4,6 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:typed_data';
-
 import 'package:cbor/cbor.dart' as cbor;
 
 import '../../definitions/data_schema.dart';
@@ -14,23 +12,21 @@ import 'content_codec.dart';
 /// A [ContentCodec] that encodes and decodes CBOR data.
 class CborCodec extends ContentCodec {
   @override
-  ByteBuffer valueToBytes(
+  List<int> valueToBytes(
     Object? value,
     DataSchema? dataSchema,
     Map<String, String>? parameters,
   ) {
-    final result = cbor.cborEncode(cbor.CborValue(value));
-    return Uint8List.fromList(result).buffer;
+    return cbor.cborEncode(cbor.CborValue(value));
   }
 
   @override
   Object? bytesToValue(
-    ByteBuffer bytes,
+    List<int> bytes,
     DataSchema? dataSchema,
     Map<String, String>? parameters,
   ) {
     // TODO(JKRhb): Use dataSchema for validation
-    final result = cbor.cborDecode(bytes.asUint8List().toList(growable: false));
-    return result.toObject();
+    return cbor.cborDecode(bytes).toObject();
   }
 }

--- a/lib/src/core/codecs/content_codec.dart
+++ b/lib/src/core/codecs/content_codec.dart
@@ -4,14 +4,12 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:typed_data';
-
 import '../../definitions/data_schema.dart';
 
 /// Interface for providing a codec for a specific media type.
 abstract class ContentCodec {
   /// Converts an [Object] to its byte representation in the given media type.
-  ByteBuffer valueToBytes(
+  List<int> valueToBytes(
     Object? value,
     DataSchema? dataSchema,
     Map<String, String>? parameters,
@@ -19,7 +17,7 @@ abstract class ContentCodec {
 
   /// Converts a payload of the given media type to an [Object].
   Object? bytesToValue(
-    ByteBuffer bytes,
+    List<int> bytes,
     DataSchema? dataSchema,
     Map<String, String>? parameters,
   );

--- a/lib/src/core/codecs/json_codec.dart
+++ b/lib/src/core/codecs/json_codec.dart
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import 'dart:convert';
-import 'dart:typed_data';
 
 import '../../definitions/data_schema.dart';
 
@@ -14,28 +13,22 @@ import 'content_codec.dart';
 /// A [ContentCodec] that encodes and decodes JSON data.
 class JsonCodec extends ContentCodec {
   @override
-  ByteBuffer valueToBytes(
+  List<int> valueToBytes(
     Object? value,
     DataSchema? dataSchema,
     Map<String, String>? parameters,
   ) {
-    if (value == null) {
-      return Uint8List(0).buffer;
-    } else {
-      // TODO(JKRhb): This probably has to be revisited
-      final utf8List = utf8.encode(jsonEncode(value));
-      return Uint8List.fromList(utf8List).buffer;
-    }
+    return utf8.encode(jsonEncode(value));
   }
 
   @override
   Object? bytesToValue(
-    ByteBuffer bytes,
+    List<int> bytes,
     DataSchema? dataSchema,
     Map<String, String>? parameters,
   ) {
     // TODO(JKRhb): Use dataSchema for validation
 
-    return jsonDecode(utf8.decoder.convert(bytes.asUint8List()));
+    return jsonDecode(utf8.decoder.convert(bytes));
   }
 }

--- a/lib/src/core/codecs/link_format_codec.dart
+++ b/lib/src/core/codecs/link_format_codec.dart
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:coap/coap.dart';
 
@@ -17,7 +16,7 @@ import 'content_codec.dart';
 /// [RFC 6690]: https://datatracker.ietf.org/doc/html/rfc6690
 class LinkFormatCodec extends ContentCodec {
   @override
-  ByteBuffer valueToBytes(
+  List<int> valueToBytes(
     Object? value,
     DataSchema? dataSchema,
     Map<String, String>? parameters,
@@ -25,8 +24,7 @@ class LinkFormatCodec extends ContentCodec {
     // TODO(JKRhb): The question which value types are allowed needs to be
     //              revisited.
     if (value is CoapResource) {
-      return Uint8List.fromList(CoapLinkFormat.serialize(value).codeUnits)
-          .buffer;
+      return CoapLinkFormat.serialize(value).codeUnits;
     }
 
     throw FormatException('Error deserializing CoRE Link Format', value);
@@ -34,11 +32,11 @@ class LinkFormatCodec extends ContentCodec {
 
   @override
   Object? bytesToValue(
-    ByteBuffer bytes,
+    List<int> bytes,
     DataSchema? dataSchema,
     Map<String, String>? parameters,
   ) {
-    final string = utf8.decode(bytes.asUint8List().toList(growable: false));
+    final string = utf8.decode(bytes);
     return CoapLinkFormat.parse(string);
   }
 }

--- a/lib/src/core/content.dart
+++ b/lib/src/core/content.dart
@@ -30,6 +30,10 @@ class Content {
     }
     return buffer.buffer;
   }
+
+  /// Converts the [body] of this [Content] to a [List] of bytes asynchronously.
+  Future<List<int>> toByteList() async =>
+      body.expand<int>((element) => element).toList();
 }
 
 /// [Content] specific for discovery.

--- a/lib/src/core/content.dart
+++ b/lib/src/core/content.dart
@@ -24,10 +24,8 @@ class Content {
 
   /// Converts the [body] of the content to a [ByteBuffer] asynchronously.
   Future<ByteBuffer> get byteBuffer async {
-    final buffer = Uint8Buffer();
-    await for (final bytes in body) {
-      buffer.addAll(bytes);
-    }
+    final buffer = Uint8Buffer()..addAll(await toByteList());
+
     return buffer.buffer;
   }
 

--- a/lib/src/core/content_serdes.dart
+++ b/lib/src/core/content_serdes.dart
@@ -6,7 +6,6 @@
 
 import 'dart:convert';
 import 'dart:io';
-import 'dart:typed_data';
 
 import 'package:http_parser/http_parser.dart';
 import 'package:json_schema/json_schema.dart';
@@ -169,19 +168,19 @@ class ContentSerdes {
     final mimeType = parsedMediaType.mimeType;
     final parameters = parsedMediaType.parameters;
 
-    ByteBuffer bytes;
+    List<int> bytes;
     final codec = _getCodecFromMediaType(mimeType);
+
     if (codec != null) {
       bytes = codec.valueToBytes(value, dataSchema, parameters);
     } else {
       // Media Type is unsupported. Convert the String representation to bytes
       // instead.
       // TODO(JKRhb): Could be moved to a dedicated Value class method.
-      bytes = utf8.encoder.convert(value.toString()).buffer;
+      bytes = utf8.encoder.convert(value.toString());
     }
 
-    final byteList = bytes.asUint8List().toList(growable: false);
-    return Content(resolvedMediaType, Stream.value(byteList));
+    return Content(resolvedMediaType, Stream.value(bytes));
   }
 
   /// Converts a [Content] object to a typed [Object].
@@ -197,10 +196,10 @@ class ContentSerdes {
     final mimeType = parsedMediaType.mimeType;
     final parameters = parsedMediaType.parameters;
 
-    final bytes = await content.byteBuffer;
+    final bytes = await content.toByteList();
 
     // TODO: Should null be returned in this case?
-    if (bytes.lengthInBytes == 0) {
+    if (bytes.isEmpty) {
       return null;
     }
 
@@ -211,7 +210,7 @@ class ContentSerdes {
       return value;
     } else {
       // TODO(JKRhb): Should unsupported data be returned as a String?
-      return utf8.decode(bytes.asUint8List());
+      return utf8.decode(bytes.toList());
     }
   }
 }


### PR DESCRIPTION
This PR makes the internal handling of the `Content` class easier by allowing for the conversion of streams into lists of (unsigned) integers instead of buffers, which gets rid of a few conversion steps.