### PR TITLE
chore: remove `dart_code_metrics` dev dependency

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,16 +48,6 @@ test:
         coverage_format: cobertura
         path: coverage.xml
 
-code_quality:
-  stage: test
-  script:
-    - dart run dart_code_metrics:metrics analyze lib -r gitlab > quality.json
-  artifacts:
-    when: always
-    reports:
-      codequality:
-        - quality.json
-
 code_navigation:
   stage: test
   allow_failure: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ environment:
 dev_dependencies:
   build_runner: ^2.3.0
   coverage: ^1.0.4
-  dart_code_metrics: ^5.7.4
   lint: ^2.0.2
   lints: ^2.0.2
   mockito: ^5.0.17


### PR DESCRIPTION
As the `dart_code_metrics` is about to be deprecated (see, e.g., its [pub.dev page](https://pub.dev/packages/dart_code_metrics)), this PR proposes removing it from the `pubspec.yaml` file.

Since `dart_code_metrics` depends on the `http` package, the dependency currently is a blocker for upgrading the `http` package for `dart_wot`, which is resolved by the removal.