### PR TITLE
feat(binding_mqtt): support MQTT URI scheme

### DIFF
--- a/lib/src/binding_mqtt/mqtt_extensions.dart
+++ b/lib/src/binding_mqtt/mqtt_extensions.dart
@@ -9,9 +9,12 @@ import "package:mqtt_client/mqtt_client.dart";
 import "package:mqtt_client/mqtt_server_client.dart";
 import "package:uuid/uuid.dart";
 
-import "../../core.dart";
-import "constants.dart";
-import "mqtt_binding_exception.dart";
+import '../../core.dart';
+import '../definitions/form.dart';
+import '../definitions/security/auto_security_scheme.dart';
+import '../definitions/security/basic_security_scheme.dart';
+import '../definitions/validation/validation_exception.dart';
+import 'constants.dart';
 
 /// [PrefixMapping] for expanding MQTT Vocabulary terms from compact IRIs.
 final mqttPrefixMapping = PrefixMapping(defaultPrefixValue: mqttContextUri);

--- a/lib/src/binding_mqtt/mqtt_extensions.dart
+++ b/lib/src/binding_mqtt/mqtt_extensions.dart
@@ -107,15 +107,17 @@ extension MqttFormExtension on AugmentedForm {
 
   /// Gets the MQTT topic for subscribing from this [Form].
   ///
-  /// Throws an [Exception] if no topic could be retrieved.
+  /// If present, this getter uses the dedicated vocabulary term `filter`.
+  /// Otherwise, the URI query from the `href` field is being used as a
+  /// fallback.
   String get topicFilter {
     final topic = _obtainVocabularyTerm<String>("filter");
 
-    if (topic == null) {
-      throw MqttBindingException("MQTT topic was not defined on form.");
+    if (topic != null) {
+      return topic;
     }
 
-    return topic;
+    return Uri.decodeComponent(href.query.replaceAll("&", "/"));
   }
 
   /// Gets the MQTT `retain` value from this [Form] if present.

--- a/lib/src/binding_mqtt/mqtt_extensions.dart
+++ b/lib/src/binding_mqtt/mqtt_extensions.dart
@@ -9,12 +9,8 @@ import "package:mqtt_client/mqtt_client.dart";
 import "package:mqtt_client/mqtt_server_client.dart";
 import "package:uuid/uuid.dart";
 
-import '../../core.dart';
-import '../definitions/form.dart';
-import '../definitions/security/auto_security_scheme.dart';
-import '../definitions/security/basic_security_scheme.dart';
-import '../definitions/validation/validation_exception.dart';
-import 'constants.dart';
+import "../../core.dart";
+import "constants.dart";
 
 /// [PrefixMapping] for expanding MQTT Vocabulary terms from compact IRIs.
 final mqttPrefixMapping = PrefixMapping(defaultPrefixValue: mqttContextUri);
@@ -62,6 +58,16 @@ extension MqttUriExtension on Uri {
 
     throw StateError("MQTT URI scheme $scheme is not supported.");
   }
+
+  String get _mqttTopic {
+    final path = Uri.decodeComponent(this.path);
+
+    if (path.isEmpty) {
+      return path;
+    }
+
+    return path.substring(1);
+  }
 }
 
 /// Additional methods for making MQTT [Form]s easier to work with.
@@ -99,20 +105,13 @@ extension MqttFormExtension on AugmentedForm {
       return topic;
     }
 
-    final path = Uri.decodeComponent(href.path);
-
-    if (path.isEmpty) {
-      return path;
-    }
-
-    return path.substring(1);
+    return href._mqttTopic;
   }
 
   /// Gets the MQTT topic for subscribing from this [Form].
   ///
   /// If present, this getter uses the dedicated vocabulary term `filter`.
-  /// Otherwise, the URI query from the `href` field is being used as a
-  /// fallback.
+  /// Otherwise, the URI path from the `href` field is being used as a fallback.
   String get topicFilter {
     final topic = _obtainVocabularyTerm<String>("filter");
 
@@ -120,7 +119,7 @@ extension MqttFormExtension on AugmentedForm {
       return topic;
     }
 
-    return Uri.decodeComponent(href.query.replaceAll("&", "/"));
+    return href._mqttTopic;
   }
 
   /// Gets the MQTT `retain` value from this [Form] if present.

--- a/lib/src/binding_mqtt/mqtt_extensions.dart
+++ b/lib/src/binding_mqtt/mqtt_extensions.dart
@@ -87,15 +87,22 @@ extension MqttFormExtension on AugmentedForm {
 
   /// Gets the MQTT topic for publishing from this [Form].
   ///
-  /// Throws an [Exception] if no topic could be retrieved.
+  /// If present, this getter uses the dedicated vocabulary term `topic`.
+  /// Otherwise, the URI path from the `href` field is being used as a fallback.
   String get topicName {
     final topic = _obtainVocabularyTerm<String>("topic");
 
-    if (topic == null) {
-      throw MqttBindingException("MQTT topic was not defined on form.");
+    if (topic != null) {
+      return topic;
     }
 
-    return topic;
+    final path = Uri.decodeComponent(href.path);
+
+    if (path.isEmpty) {
+      return path;
+    }
+
+    return path.substring(1);
   }
 
   /// Gets the MQTT topic for subscribing from this [Form].


### PR DESCRIPTION
This PR adds support for the use of the MQTT URI scheme that is currently being discussed in https://github.com/w3c/wot-binding-templates/issues/292.

An open question here is how to deal with the `topic` vocabulary term. With the implementation in this PR, it is being treated as an "override", but maybe it also becomes obsolete when the new URI scheme is in place.