### PR TITLE
fix: fix duplicate URI detection during MDNS discovery

### DIFF
--- a/lib/src/core/thing_discovery.dart
+++ b/lib/src/core/thing_discovery.dart
@@ -298,7 +298,7 @@ class ThingDiscovery extends Stream<ThingDescription>
           scheme: txtRecords['scheme'] ?? defaultScheme,
         );
 
-        final duplicate = discoveredUris.add(uri);
+        final duplicate = !discoveredUris.add(uri);
 
         if (duplicate) {
           continue;


### PR DESCRIPTION
Noticed that the logic that is used to determine whether a discovered URI is a duplicate has been reversed so far. This PR applies a simple fix.