### PR TITLE
chore!: do not expose the TD ID via AugmentedForms

### DIFF
--- a/example/complex_example.dart
+++ b/example/complex_example.dart
@@ -76,18 +76,15 @@ const thingDescriptionJson = {
 };
 
 final Map<String, BasicCredentials> basicCredentials = {
-  "urn:test": const BasicCredentials("username", "password"),
+  "httpbin.org": const BasicCredentials("username", "password"),
 };
 
 Future<BasicCredentials?> basicCredentialsCallback(
   Uri uri,
-  AugmentedForm? form, [
+  AugmentedForm? form,
   BasicCredentials? invalidCredentials,
-]) async {
-  final id = form?.tdIdentifier;
-
-  return basicCredentials[id];
-}
+) async =>
+    basicCredentials[uri.authority];
 
 Future<void> main() async {
   final coapClientFactory = CoapClientFactory(

--- a/example/http_basic_authentication.dart
+++ b/example/http_basic_authentication.dart
@@ -38,22 +38,15 @@ const thingDescriptionJson = {
 const basicCredentials = BasicCredentials("username", "password");
 
 final Map<String, BasicCredentials> basicCredentialsMap = {
-  "urn:test": basicCredentials,
+  "httpbin.org": basicCredentials,
 };
 
 Future<BasicCredentials?> basicCredentialsCallback(
   Uri uri,
   AugmentedForm? form,
   BasicCredentials? invalidCredentials,
-) async {
-  if (form == null) {
-    return basicCredentials;
-  }
-
-  final id = form.tdIdentifier;
-
-  return basicCredentialsMap[id];
-}
+) async =>
+    basicCredentialsMap[uri.authority];
 
 /// Illustrates the usage of both the basic and the automatic security scheme,
 /// with a server supporting basic authentication.

--- a/example/mqtt_example.dart
+++ b/example/mqtt_example.dart
@@ -46,18 +46,18 @@ const thingDescriptionJson = {
 };
 
 final Map<String, BasicCredentials> basicCredentials = {
-  "urn:test": const BasicCredentials("rw", "readwrite"),
+  "test.mosquitto.org:1884": const BasicCredentials(
+    "rw",
+    "readwrite",
+  ),
 };
 
 Future<BasicCredentials?> basicCredentialsCallback(
   Uri uri,
   AugmentedForm? form, [
   BasicCredentials? invalidCredentials,
-]) async {
-  final id = form?.tdIdentifier;
-
-  return basicCredentials[id];
-}
+]) async =>
+    basicCredentials[uri.authority];
 
 Future<void> main(List<String> args) async {
   final servient = Servient.create(

--- a/lib/src/binding_coap/coap_client.dart
+++ b/lib/src/binding_coap/coap_client.dart
@@ -132,7 +132,7 @@ final class CoapClient extends ProtocolClient
     final code = requestMethod.code;
 
     return _sendRequest(
-      form.resolvedHref,
+      form.href,
       code,
       content: content,
       format: form.contentFormat,
@@ -232,7 +232,7 @@ final class CoapClient extends ProtocolClient
   ) async {
     final requestMethod = (form.method ?? CoapRequestMethod.get).code;
 
-    final creationHintUri = form.resolvedHref.replace(scheme: "coap");
+    final creationHintUri = form.href.replace(scheme: "coap");
 
     final request = await _createRequest(
       requestMethod,
@@ -419,13 +419,13 @@ final class CoapClient extends ProtocolClient
 
     final request = await _createRequest(
       (form.method ?? CoapRequestMethod.get).code,
-      form.resolvedHref,
+      form.href,
       format: form.contentFormat,
       accept: form.accept,
     );
 
     final coapClient = coap.CoapClient(
-      form.resolvedHref,
+      form.href,
       config: _InternalCoapConfig(_coapConfig ?? const CoapConfig()),
     );
 

--- a/lib/src/binding_http/http_client.dart
+++ b/lib/src/binding_http/http_client.dart
@@ -104,8 +104,7 @@ final class HttpClient extends ProtocolClient
       return false;
     }
 
-    final basicCredentials =
-        await _getBasicCredentials(form.resolvedHref, form);
+    final basicCredentials = await _getBasicCredentials(form.href, form);
 
     if (basicCredentials == null) {
       return false;
@@ -127,8 +126,7 @@ final class HttpClient extends ProtocolClient
       return false;
     }
 
-    final bearerCredentials =
-        await _getBearerCredentials(form.resolvedHref, form);
+    final bearerCredentials = await _getBearerCredentials(form.href, form);
 
     if (bearerCredentials == null) {
       return false;
@@ -222,7 +220,7 @@ final class HttpClient extends ProtocolClient
   ) async {
     final requestMethod =
         HttpRequestMethod.getRequestMethod(form, operationType);
-    final Uri uri = form.resolvedHref;
+    final Uri uri = form.href;
 
     final request = Request(requestMethod.methodName, uri)
       ..headers.addAll(_getHeadersFromForm(form))

--- a/lib/src/binding_http/http_subscription.dart
+++ b/lib/src/binding_http/http_subscription.dart
@@ -20,7 +20,7 @@ final class HttpSseSubscription extends ProtocolSubscription {
     void Function(Exception error)? onError,
     void Function()? complete,
   })  : _active = true,
-        _sseChannel = SseChannel.connect(form.resolvedHref) {
+        _sseChannel = SseChannel.connect(form.href) {
     _sseChannel.stream.listen(
       (data) {
         if (data is! String) {

--- a/lib/src/binding_mqtt/mqtt_client.dart
+++ b/lib/src/binding_mqtt/mqtt_client.dart
@@ -68,7 +68,7 @@ final class MqttClient extends ProtocolClient with MqttDiscoverer {
   }
 
   Future<MqttServerClient> _connectWithForm(AugmentedForm form) async =>
-      _connect(form.resolvedHref, form);
+      _connect(form.href, form);
 
   Future<MqttServerClient> _connect(Uri brokerUri, AugmentedForm? form) async {
     final client = brokerUri.createClient(_mqttConfig.keepAlivePeriod);

--- a/lib/src/binding_mqtt/mqtt_extensions.dart
+++ b/lib/src/binding_mqtt/mqtt_extensions.dart
@@ -140,8 +140,7 @@ extension MqttFormExtension on AugmentedForm {
     if (qosValue != null) {
       throw FormatException(
         "Encountered unknown QoS value $qosValue. "
-        "in form with href $href of Thing Description with Identifier "
-        "$tdIdentifier.",
+        "in form with resolved href $resolvedHref.",
       );
     }
 

--- a/lib/src/binding_mqtt/mqtt_extensions.dart
+++ b/lib/src/binding_mqtt/mqtt_extensions.dart
@@ -140,7 +140,7 @@ extension MqttFormExtension on AugmentedForm {
     if (qosValue != null) {
       throw FormatException(
         "Encountered unknown QoS value $qosValue. "
-        "in form with resolved href $resolvedHref.",
+        "in form with resolved href $href.",
       );
     }
 

--- a/lib/src/core/implementation/augmented_form.dart
+++ b/lib/src/core/implementation/augmented_form.dart
@@ -44,8 +44,9 @@ final class AugmentedForm implements Form {
   @override
   String get contentType => _form.contentType;
 
-  @override
-  Uri get href {
+  /// Resolves all [_userProvidedUriVariables] in this [Form] and returns the
+  /// resulting [Uri].
+  Uri get _resolvedHref {
     final baseUri = _thingDescription.base;
 
     if (baseUri != null) {
@@ -53,6 +54,39 @@ final class AugmentedForm implements Form {
     }
 
     return _form.href;
+  }
+
+  @override
+  Uri get href {
+    final href = _resolvedHref;
+    final hrefUriVariables = _filterUriVariables(href);
+
+    if (hrefUriVariables.isEmpty) {
+      return href;
+    }
+
+    final Map<String, DataSchema> affordanceUriVariables = {
+      ..._thingDescription.uriVariables ?? {},
+      ..._interactionAffordance.uriVariables ?? {},
+    };
+
+    final userProvidedUriVariables = _userProvidedUriVariables;
+
+    if (userProvidedUriVariables != null) {
+      _validateUriVariables(
+        hrefUriVariables,
+        affordanceUriVariables,
+        userProvidedUriVariables,
+      );
+    }
+
+    // As "{" and "}" are "percent encoded" due to Uri.parse(), we need to
+    // revert the encoding first before we can insert the values.
+    final decodedHref = Uri.decodeFull(href.toString());
+
+    final expandedHref =
+        UriTemplate(decodedHref).expand(userProvidedUriVariables ?? {});
+    return Uri.parse(expandedHref);
   }
 
   @override
@@ -93,38 +127,6 @@ final class AugmentedForm implements Form {
         .map((e) => e.split(","))
         .flattened
         .toList(growable: false);
-  }
-
-  /// Resolves all [_userProvidedUriVariables] in this [Form] and returns the
-  /// resulting [Uri].
-  Uri get resolvedHref {
-    final hrefUriVariables = _filterUriVariables(href);
-
-    if (hrefUriVariables.isEmpty) {
-      return href;
-    }
-
-    final Map<String, DataSchema> affordanceUriVariables = {
-      ..._thingDescription.uriVariables ?? {},
-      ..._interactionAffordance.uriVariables ?? {},
-    };
-
-    final userProvidedUriVariables = _userProvidedUriVariables;
-    if (userProvidedUriVariables != null) {
-      _validateUriVariables(
-        hrefUriVariables,
-        affordanceUriVariables,
-        userProvidedUriVariables,
-      );
-    }
-
-    // As "{" and "}" are "percent encoded" due to Uri.parse(), we need to
-    // revert the encoding first before we can insert the values.
-    final decodedHref = Uri.decodeFull(href.toString());
-
-    final expandedHref =
-        UriTemplate(decodedHref).expand(userProvidedUriVariables ?? {});
-    return Uri.parse(expandedHref);
   }
 
   void _validateUriVariables(

--- a/lib/src/core/implementation/augmented_form.dart
+++ b/lib/src/core/implementation/augmented_form.dart
@@ -31,9 +31,6 @@ final class AugmentedForm implements Form {
 
   final Map<String, Object>? _userProvidedUriVariables;
 
-  /// The identifier of the [_thingDescription] associated with this form.
-  String get tdIdentifier => _thingDescription.identifier;
-
   @override
   Map<String, dynamic> get additionalFields => _form.additionalFields;
 

--- a/lib/src/core/implementation/consumed_thing.dart
+++ b/lib/src/core/implementation/consumed_thing.dart
@@ -78,7 +78,7 @@ class ConsumedThing implements scripting_api.ConsumedThing {
           }
 
           return servient.supportsOperation(
-            form.resolvedHref.scheme,
+            form.href.scheme,
             operationType,
             form.subprotocol,
           );

--- a/test/core/augmented_form_test.dart
+++ b/test/core/augmented_form_test.dart
@@ -144,13 +144,8 @@ void main() {
       );
 
       expect(
-        augmentedForm1.resolvedHref,
+        augmentedForm1.href,
         Uri.parse("http://example.org/weather/?lat=5&long=10"),
-      );
-
-      expect(
-        augmentedForm1.resolvedHref != augmentedForm1.href,
-        isTrue,
       );
 
       final augmentedForm2 = AugmentedForm(
@@ -163,7 +158,7 @@ void main() {
       );
 
       expect(
-        augmentedForm2.resolvedHref,
+        augmentedForm2.href,
         Uri.parse("http://example.org/weather/?lat=5"),
       );
 
@@ -177,7 +172,7 @@ void main() {
       );
 
       expect(
-        augmentedForm3.resolvedHref,
+        augmentedForm3.href,
         Uri.parse("http://example.org/weather/?long=10"),
       );
 
@@ -192,7 +187,7 @@ void main() {
       );
 
       expect(
-        () => augmentedForm4.resolvedHref,
+        () => augmentedForm4.href,
         throwsA(isA<FormatException>()),
       );
 
@@ -207,20 +202,8 @@ void main() {
       );
 
       expect(
-        () => augmentedForm5.resolvedHref,
+        () => augmentedForm5.href,
         throwsA(isA<FormatException>()),
-      );
-
-      final augmentedForm6 = AugmentedForm(
-        affordance.forms[2],
-        affordance,
-        thingDescription,
-        const {},
-      );
-
-      expect(
-        augmentedForm6.href,
-        augmentedForm6.resolvedHref,
       );
     });
   });

--- a/test/core/augmented_form_test.dart
+++ b/test/core/augmented_form_test.dart
@@ -63,7 +63,6 @@ void main() {
       expect(augmentedForm.href, Uri.parse(href));
       expect(augmentedForm.security, ["nosec_sc"]);
       expect(augmentedForm.securityDefinitions.first, isA<NoSecurityScheme>());
-      expect(augmentedForm.tdIdentifier, id);
       expect(
         augmentedForm.additionalResponses?.first.contentType,
         "application/json",

--- a/test/core/discovery_test.dart
+++ b/test/core/discovery_test.dart
@@ -147,7 +147,7 @@ final class _MockedProtocolClient extends ProtocolClient with DirectDiscoverer {
 
   @override
   Future<Content> readResource(AugmentedForm form) async {
-    final href = form.resolvedHref;
+    final href = form.href;
 
     if (href == directoryTestThingsUri1) {
       return "[$validTestThingDescription]".toContent("application/td+json");


### PR DESCRIPTION
As discussed in https://github.com/eclipse-thingweb/node-wot/issues/1342, this PR removes the `tdIdentifier`that has previously been exposed by the `AugmentedForm` class.