### PR TITLE
chore(mqtt_example.dart): remove incorrect base field

### DIFF
--- a/example/mqtt_example.dart
+++ b/example/mqtt_example.dart
@@ -13,7 +13,6 @@ const thingDescriptionJson = {
   "@context": "https://www.w3.org/2022/wot/td/v1.1",
   "title": "Test Thing",
   "id": "urn:test",
-  "base": "coap://coap.me",
   "security": ["auto_sc"],
   "securityDefinitions": {
     "auto_sc": {"scheme": "auto"},


### PR DESCRIPTION
This PR applies a small fix to the TD that is used in the MQTT example.